### PR TITLE
Change saturating truncation operator names

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -163,7 +163,7 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f32x4.convert_u/i32x4`   |      133 | -                  |
 | `f64x2.convert_s/i64x2`   |      134 | -                  |
 | `f64x2.convert_u/i64x2`   |      135 | -                  |
-| `i32x4.trunc_s/f32x4:sat` |      136 | -                  |
-| `i32x4.trunc_u/f32x4:sat` |      137 | -                  |
-| `i64x2.trunc_s/f64x2:sat` |      138 | -                  |
-| `i64x2.trunc_u/f64x2:sat` |      139 | -                  |
+| `i32x4.trunc_s:sat/f32x4` |      136 | -                  |
+| `i32x4.trunc_u:sat/f32x4` |      137 | -                  |
+| `i64x2.trunc_s:sat/f64x2` |      138 | -                  |
+| `i64x2.trunc_u:sat/f64x2` |      139 | -                  |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -665,10 +665,10 @@ Lane-wise conversion from integer to floating point. Some integer values will be
 rounded.
 
 ### Floating point to integer with saturation
-* `i32x4.trunc_s/f32x4:sat(a: v128) -> v128`
-* `i32x4.trunc_u/f32x4:sat(a: v128) -> v128`
-* `i64x2.trunc_s/f64x2:sat(a: v128) -> v128`
-* `i64x2.trunc_u/f64x2:sat(a: v128) -> v128`
+* `i32x4.trunc_s:sat/f32x4(a: v128) -> v128`
+* `i32x4.trunc_u:sat/f32x4(a: v128) -> v128`
+* `i64x2.trunc_s:sat/f64x2(a: v128) -> v128`
+* `i64x2.trunc_u:sat/f64x2(a: v128) -> v128`
 
 Lane-wise saturating conversion from floating point to integer using the IEEE
 `convertToIntegerTowardZero` function. If any input lane is a NaN, the


### PR DESCRIPTION
This changes saturating truncation operators to place the ":sat" modifier immediately after the trunc_u or trunc_s, instead of after the source type. e.g:
`i32x4.trunc_s:sat/f32x4` instead of `i32.trunc_s/f32x4:sat`

This resolves https://github.com/WebAssembly/simd/issues/25