### PR TITLE
Rename LaneIdx{2,4,8,16,32} to ImmLaneIdx{2,4,8,16,32}

### DIFF
--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -48,7 +48,7 @@ For example, the instructions `f32x4.extract_lane` and `i64x2.extract_lane`
 perform the same semantic operation: extracting the scalar value of a vector
 lane. However, the `f32x4.extract_lane` instruction returns a 32-bit wide
 floating point value, while the `i64x2.extract_lane` instruction returns a
-64-bit wide floating point value.
+64-bit wide integer value.
 
 The interpretations form a hierarchy with successive refinements, where `v128`
 is at the top of the hierarchy and interprets the `v128` vector type as a bag of

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -50,12 +50,10 @@ lane. However, the `f32x4.extract_lane` instruction returns a 32-bit wide
 floating point value, while the `i64x2.extract_lane` instruction returns a
 64-bit wide integer value.
 
-The interpretations form a hierarchy with successive refinements, where `v128`
-is at the top of the hierarchy and interprets the `v128` vector type as a bag of
-bits. The `v32x4` refines `v128` (`v32x4 : v128`) and interprets the vector as 4
-32-bit wide lane, while the `i32x4` and `f32x4` both refine `v32x4` and
-interpret the content of the vector lanes as being of integer or floating-point
-types.
+The `v128` vector type interpretation interprets the vector as a bag of bits. 
+The `v{lane_width}x{n}` interpretations (e.g. `v32x4`) interpret the vector as
+`n` lanes of `lane_width` bits. The `{t}{lane_width}x{n}` interpretations (e.g.
+`i32x4` or `f32x4`) interpret the vector as `n` lanes of type `{t}{lane_width}`.
 
 ### Lane division interpretation
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -13,12 +13,13 @@ of immediate operands used by the SIMD instructions.
 
 ## SIMD value type
 
-The `v128` value type has a concrete mapping to a 128-bit representation with bits
-numbered 0–127. The `v128` type corresponds to a vector register in a typical
-SIMD ISA. The interpretation of the 128 bits in the vector register is provided
-by the individual instructions. When a `v128` value is represented as 16 bytes,
-bits 0-7 go in the first byte with bit 0 as the LSB, bits 8-15 go in the second
-byte, etc.
+The `v128` value type is the _only_ type introduced in this extension. It has a
+concrete mapping to a 128-bit representation with bits numbered 0–127. The
+`v128` type corresponds to a vector register in a typical SIMD ISA. The
+interpretation of the 128 bits in the vector register is provided by the
+individual instructions. When a `v128` value is represented as 16 bytes, bits
+0-7 go in the first byte with bit 0 as the LSB, bits 8-15 go in the second byte,
+etc.
 
 ## Immediate operands
 
@@ -33,11 +34,28 @@ range, and it is a validation error if the immediate operands are out of range.
 * `ImmLaneIdx16`: A byte with values in the range 0–15 identifying a lane.
 * `ImmLaneIdx32`: A byte with values in the range 0–31 identifying a lane.
 
-## Interpreting the SIMD value type
+## Operations on the SIMD value type
 
-The single `v128` SIMD type can represent packed data in multiple ways.
-Instructions specify how the bits should be interpreted through a hierarchy of
-*interpretations*.
+The _single_ `v128` SIMD type can be used to represent different types of packed
+data, e.g., it can represent four 32-bit floating point values, 8 16-bit signed
+or unsigned integer values, etc.
+
+The instructions introduced in this specification are named according to the
+following schema: `{interpretation}.{operation}`. Where the `{interpretation}`
+prefix denotes how the bytes of the `v128` type are interpreted by the `{operation}`. 
+
+For example, the instructions `f32x4.extract_lane` and `i64x2.extract_lane`
+perform the same semantic operation: extracting the scalar value of a vector
+lane. However, the `f32x4.extract_lane` instruction returns a 32-bit wide
+floating point value, while the `i64x2.extract_lane` instruction returns a
+64-bit wide floating point value.
+
+The interpretations form a hierarchy with successive refinements, where `v128`
+is at the top of the hierarchy and interprets the `v128` vector type as a bag of
+bits. The `v32x4` refines `v128` (`v32x4 : v128`) and interprets the vector as 4
+32-bit wide lane, while the `i32x4` and `f32x4` both refine `v32x4` and
+interpret the content of the vector lanes as being of integer or floating-point
+types.
 
 ### Lane division interpretation
 
@@ -108,7 +126,7 @@ scalar floating-point semantics which require correct subnormal handling.
 
 The SIMD operations described in this sections are generally named
 `S.Op`, where `S` is either a SIMD type or one of the interpretations
-of a SIMD type.
+of a SIMD type. Immediate mode operands are prefixed with `imm`.
 
 Many operations are simply the lane-wise application of a scalar operation:
 
@@ -143,9 +161,9 @@ def S.lanewise_comparison(func, a, b):
 ### Constant
 * `v128.const(imm: ImmByte[16]) -> v128`
 
-Materialize a constant SIMD value from the immediate operands. The `v128.const`
-instruction is encoded with 16 immediate bytes which provide the bits of the
-vector directly.
+Materialize a constant `v128` SIMD value from the 16 immediate bytes in the
+immediate mode operand `imm` . The `v128.const` instruction is encoded with 16
+immediate bytes which provide the bits of the vector directly.
 
 ### Create vector with identical lanes
 * `i8x16.splat(x: i32) -> v128`
@@ -168,16 +186,18 @@ def S.splat(x):
 ## Accessing lanes
 
 ### Extract lane as a scalar
-* `i8x16.extract_lane_s(a: v128, i: ImmLaneIdx16) -> i32`
-* `i8x16.extract_lane_u(a: v128, i: ImmLaneIdx16) -> i32`
-* `i16x8.extract_lane_s(a: v128, i: ImmLaneIdx8) -> i32`
-* `i16x8.extract_lane_u(a: v128, i: ImmLaneIdx8) -> i32`
-* `i32x4.extract_lane(a: v128, i: ImmLaneIdx4) -> i32`
-* `i64x2.extract_lane(a: v128, i: ImmLaneIdx2) -> i64`
-* `f32x4.extract_lane(a: v128, i: ImmLaneIdx4) -> f32`
-* `f64x2.extract_lane(a: v128, i: ImmLaneIdx2) -> f64`
+* `i8x16.extract_lane_s(a: v128, imm: ImmLaneIdx16) -> i32`
+* `i8x16.extract_lane_u(a: v128, imm: ImmLaneIdx16) -> i32`
+* `i16x8.extract_lane_s(a: v128, imm: ImmLaneIdx8) -> i32`
+* `i16x8.extract_lane_u(a: v128, imm: ImmLaneIdx8) -> i32`
+* `i32x4.extract_lane(a: v128, imm: ImmLaneIdx4) -> i32`
+* `i64x2.extract_lane(a: v128, imm: ImmLaneIdx2) -> i64`
+* `f32x4.extract_lane(a: v128, imm: ImmLaneIdx4) -> f32`
+* `f64x2.extract_lane(a: v128, imm: ImmLaneIdx2) -> f64`
 
-Extract the value of lane `i` in `a`.
+Extract the scalar value of lane specified in the immediate mode operand `imm`
+in `a`. The `{interpretation}.extract_lane{_s}{_u}` instructions are encoded
+with one immediate byte providing the index of the lane to extract.
 
 ```python
 def S.extract_lane(a, i):
@@ -188,15 +208,17 @@ The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
 `i32` respectively.
 
 ### Replace lane value
-* `i8x16.replace_lane(a: v128, i: ImmLaneIdx16, x: i32) -> v128`
-* `i16x8.replace_lane(a: v128, i: ImmLaneIdx8, x: i32) -> v128`
-* `i32x4.replace_lane(a: v128, i: ImmLaneIdx4, x: i32) -> v128`
-* `i64x2.replace_lane(a: v128, i: ImmLaneIdx2, x: i64) -> v128`
-* `f32x4.replace_lane(a: v128, i: ImmLaneIdx4, x: f32) -> v128`
-* `f64x2.replace_lane(a: v128, i: ImmLaneIdx2, x: f64) -> v128`
+* `i8x16.replace_lane(a: v128, imm: ImmLaneIdx16, x: i32) -> v128`
+* `i16x8.replace_lane(a: v128, imm: ImmLaneIdx8, x: i32) -> v128`
+* `i32x4.replace_lane(a: v128, imm: ImmLaneIdx4, x: i32) -> v128`
+* `i64x2.replace_lane(a: v128, imm: ImmLaneIdx2, x: i64) -> v128`
+* `f32x4.replace_lane(a: v128, imm: ImmLaneIdx4, x: f32) -> v128`
+* `f64x2.replace_lane(a: v128, imm: ImmLaneIdx2, x: f64) -> v128`
 
-Return a new vector with lanes identical to `a`, except for lane `i` which has
-the value `x`.
+Return a new vector with lanes identical to `a`, except for the lane specified
+in the immediate mode operand `imm` which has the value `x`. The
+`{interpretation}.replace_lane` instructions are encoded with one immediate byte
+providing the index of the lane to whose value is to be replaced.
 
 ```python
 def S.replace_lane(a, i, x):
@@ -211,9 +233,13 @@ The input lane value, `x`, is interpreted the same way as for the splat
 instructions. For the `i8` and `i16` lanes, the high bits of `x` are ignored.
 
 ### Shuffle lanes
-* `v8x16.shuffle(a: v128, b: v128, s: ImmLaneIdx32[16]) -> v128`
+* `v8x16.shuffle(a: v128, b: v128, imm: ImmLaneIdx32[16]) -> v128`
 
-Create vector with lanes selected from the lanes of two input vectors:
+Returns a new vector with lanes selected from the lanes of the two input vectors
+`a` and `b` specified in the 16 byte wide immediate mode operand `imm`. This
+instruction is encoded with 16 bytes providing the indices of the elements to
+return. The indices `i` in range `[0, 15]` select the `i`-th element of `a`. The
+indices in range `[16, 31]` select the `i - 16`-th element of `b`.
 
 ```python
 def S.shuffle(a, b, s):

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -217,8 +217,8 @@ The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
 
 Return a new vector with lanes identical to `a`, except for the lane specified
 in the immediate mode operand `imm` which has the value `x`. The
-`{interpretation}.replace_lane` instructions are encoded with one immediate byte
-providing the index of the lane to whose value is to be replaced.
+`{interpretation}.replace_lane` instructions are encoded with an immediate byte 
+providing the index of the lane the value of which is to be replaced.
 
 ```python
 def S.replace_lane(a, i, x):

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -588,13 +588,13 @@ memory access size is 16 bytes which is also the natural alignment.
 
 ### Load
 
-* `v128.load(memarg) -> v128`
+* `v128.load(imm: memarg) -> v128`
 
 Load a `v128` vector from the given heap address.
 
 ### Store
 
-* `v128.store(memarg, data: v128)`
+* `v128.store(imm: memarg, data: v128)`
 
 Store a `v128` vector to the given heap address.
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -27,11 +27,11 @@ encoded as individual bytes in the binary encoding. Many have a limited valid
 range, and it is a validation error if the immediate operands are out of range.
 
 * `ImmByte`: A single unconstrained byte (0-255).
-* `LaneIdx2`: A byte with values in the range 0–1 identifying a lane.
-* `LaneIdx4`: A byte with values in the range 0–3 identifying a lane.
-* `LaneIdx8`: A byte with values in the range 0–7 identifying a lane.
-* `LaneIdx16`: A byte with values in the range 0–15 identifying a lane.
-* `LaneIdx32`: A byte with values in the range 0–31 identifying a lane.
+* `ImmLaneIdx2`: A byte with values in the range 0–1 identifying a lane.
+* `ImmLaneIdx4`: A byte with values in the range 0–3 identifying a lane.
+* `ImmLaneIdx8`: A byte with values in the range 0–7 identifying a lane.
+* `ImmLaneIdx16`: A byte with values in the range 0–15 identifying a lane.
+* `ImmLaneIdx32`: A byte with values in the range 0–31 identifying a lane.
 
 ## Interpreting the SIMD value type
 
@@ -168,14 +168,14 @@ def S.splat(x):
 ## Accessing lanes
 
 ### Extract lane as a scalar
-* `i8x16.extract_lane_s(a: v128, i: LaneIdx16) -> i32`
-* `i8x16.extract_lane_u(a: v128, i: LaneIdx16) -> i32`
-* `i16x8.extract_lane_s(a: v128, i: LaneIdx8) -> i32`
-* `i16x8.extract_lane_u(a: v128, i: LaneIdx8) -> i32`
-* `i32x4.extract_lane(a: v128, i: LaneIdx4) -> i32`
-* `i64x2.extract_lane(a: v128, i: LaneIdx2) -> i64`
-* `f32x4.extract_lane(a: v128, i: LaneIdx4) -> f32`
-* `f64x2.extract_lane(a: v128, i: LaneIdx2) -> f64`
+* `i8x16.extract_lane_s(a: v128, i: ImmLaneIdx16) -> i32`
+* `i8x16.extract_lane_u(a: v128, i: ImmLaneIdx16) -> i32`
+* `i16x8.extract_lane_s(a: v128, i: ImmLaneIdx8) -> i32`
+* `i16x8.extract_lane_u(a: v128, i: ImmLaneIdx8) -> i32`
+* `i32x4.extract_lane(a: v128, i: ImmLaneIdx4) -> i32`
+* `i64x2.extract_lane(a: v128, i: ImmLaneIdx2) -> i64`
+* `f32x4.extract_lane(a: v128, i: ImmLaneIdx4) -> f32`
+* `f64x2.extract_lane(a: v128, i: ImmLaneIdx2) -> f64`
 
 Extract the value of lane `i` in `a`.
 
@@ -188,12 +188,12 @@ The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
 `i32` respectively.
 
 ### Replace lane value
-* `i8x16.replace_lane(a: v128, i: LaneIdx16, x: i32) -> v128`
-* `i16x8.replace_lane(a: v128, i: LaneIdx8, x: i32) -> v128`
-* `i32x4.replace_lane(a: v128, i: LaneIdx4, x: i32) -> v128`
-* `i64x2.replace_lane(a: v128, i: LaneIdx2, x: i64) -> v128`
-* `f32x4.replace_lane(a: v128, i: LaneIdx4, x: f32) -> v128`
-* `f64x2.replace_lane(a: v128, i: LaneIdx2, x: f64) -> v128`
+* `i8x16.replace_lane(a: v128, i: ImmLaneIdx16, x: i32) -> v128`
+* `i16x8.replace_lane(a: v128, i: ImmLaneIdx8, x: i32) -> v128`
+* `i32x4.replace_lane(a: v128, i: ImmLaneIdx4, x: i32) -> v128`
+* `i64x2.replace_lane(a: v128, i: ImmLaneIdx2, x: i64) -> v128`
+* `f32x4.replace_lane(a: v128, i: ImmLaneIdx4, x: f32) -> v128`
+* `f64x2.replace_lane(a: v128, i: ImmLaneIdx2, x: f64) -> v128`
 
 Return a new vector with lanes identical to `a`, except for lane `i` which has
 the value `x`.
@@ -211,7 +211,7 @@ The input lane value, `x`, is interpreted the same way as for the splat
 instructions. For the `i8` and `i16` lanes, the high bits of `x` are ignored.
 
 ### Shuffle lanes
-* `v8x16.shuffle(a: v128, b: v128, s: LaneIdx32[16]) -> v128`
+* `v8x16.shuffle(a: v128, b: v128, s: ImmLaneIdx32[16]) -> v128`
 
 Create vector with lanes selected from the lanes of two input vectors:
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -590,13 +590,13 @@ natural alignment.
 
 ### Load
 
-* `v128.load(imm: memarg) -> v128`
+* `v128.load(memarg) -> v128`
 
 Load a `v128` vector from the given heap address.
 
 ### Store
 
-* `v128.store(imm: memarg, data: v128)`
+* `v128.store(memarg, data: v128)`
 
 Store a `v128` vector to the given heap address.
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -583,8 +583,10 @@ def S.ne(a, b):
 
 Load and store operations are provided for the `v128` vectors. The memory
 operations take the same arguments and have the same semantics as the existing
-scalar WebAssembly load and store instructions. The difference is that the
-memory access size is 16 bytes which is also the natural alignment.
+scalar WebAssembly load and store instructions (see
+[memarg](https://webassembly.github.io/spec/core/bikeshed/index.html#syntax-memarg).
+The difference is that the memory access size is 16 bytes which is also the
+natural alignment.
 
 ### Load
 


### PR DESCRIPTION
This makes it clear everywhere that `ImmLaneIdx` is an immediate operand and also makes the nomenclature for immediate operands consistent (both `ImmByte` and `ImmLaneIdx`  start with the prefix `Imm`) .

See https://github.com/WebAssembly/simd/issues/33 .