### PR TITLE
Rename truncations to avoid colon in name

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -163,7 +163,7 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f32x4.convert_u/i32x4`   |      144 | -                  |
 | `f64x2.convert_s/i64x2`   |      145 | -                  |
 | `f64x2.convert_u/i64x2`   |      146 | -                  |
-| `i32x4.trunc_s/f32x4:sat` |      147 | -                  |
-| `i32x4.trunc_u/f32x4:sat` |      148 | -                  |
-| `i64x2.trunc_s/f64x2:sat` |      149 | -                  |
-| `i64x2.trunc_u/f64x2:sat` |      150 | -                  |
+| `i32x4.trunc_saturating_s/f32x4` |      147 | -                  |
+| `i32x4.trunc_saturating_u/f32x4` |      148 | -                  |
+| `i64x2.trunc_saturating_s/f64x2` |      149 | -                  |
+| `i64x2.trunc_saturating_u/f64x2` |      150 | -                  |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -665,10 +665,10 @@ Lane-wise conversion from integer to floating point. Some integer values will be
 rounded.
 
 ### Floating point to integer with saturation
-* `i32x4.trunc_s/f32x4:sat(a: v128) -> v128`
-* `i32x4.trunc_u/f32x4:sat(a: v128) -> v128`
-* `i64x2.trunc_s/f64x2:sat(a: v128) -> v128`
-* `i64x2.trunc_u/f64x2:sat(a: v128) -> v128`
+* `i32x4.trunc_saturating_s/f32x4(a: v128) -> v128`
+* `i32x4.trunc_saturating_u/f32x4(a: v128) -> v128`
+* `i64x2.trunc_saturating_s/f64x2(a: v128) -> v128`
+* `i64x2.trunc_saturating_u/f64x2(a: v128) -> v128`
 
 Lane-wise saturating conversion from floating point to integer using the IEEE
 `convertToIntegerTowardZero` function. If any input lane is a NaN, the


### PR DESCRIPTION
Having colons in instruction names would require special handling in
existing assemblers, which seems like unnecessary extra work.