### PR TITLE
Specify v8x16.shuffle text format

### DIFF
--- a/proposals/simd/TextSIMD.md
+++ b/proposals/simd/TextSIMD.md
@@ -19,3 +19,9 @@ The canonical text format used for printing `v128.const` instructions is
 ```
 v128.const i32x4 0xNNNNNNNN 0xNNNNNNNN 0xNNNNNNNN 0xNNNNNNNN
 ```
+
+### v8x16.shuffle
+
+```
+v8x16.shuffle i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5
+```


### PR DESCRIPTION
Separate each lane index because they are always interpreted
independently.