### PR TITLE
Add Quasi-Fused Multiply-Add/Subtract instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -153,6 +153,8 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f32x4.abs`                |    `0x95`| -                  |
 | `f32x4.neg`                |    `0x96`| -                  |
 | `f32x4.sqrt`               |    `0x97`| -                  |
+| `f32x4.qfma`               |    `0x98`| -                  |
+| `f32x4.qfms`               |    `0x99`| -                  |
 | `f32x4.add`                |    `0x9a`| -                  |
 | `f32x4.sub`                |    `0x9b`| -                  |
 | `f32x4.mul`                |    `0x9c`| -                  |
@@ -162,6 +164,8 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f64x2.abs`                |    `0xa0`| -                  |
 | `f64x2.neg`                |    `0xa1`| -                  |
 | `f64x2.sqrt`               |    `0xa2`| -                  |
+| `f64x2.qfma`               |    `0xa3`| -                  |
+| `f64x2.qfms`               |    `0xa4`| -                  |
 | `f64x2.add`                |    `0xa5`| -                  |
 | `f64x2.sub`                |    `0xa6`| -                  |
 | `f64x2.mul`                |    `0xa7`| -                  |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -867,6 +867,18 @@ Lane-wise IEEE `multiplication`.
 
 Lane-wise IEEE `squareRoot`.
 
+### Quasi-Fused Multiply-Add
+* `f32x4.qfma(a: v128, b: v128, c: v128) -> v128`
+* `f64x2.qfma(a: v128, b: v128, c: v128) -> v128`
+
+Lane-wise multiplication and addition (`a + b * c`), either with, or without intermediate rounding. WebAssembly implementation may execute this instruction as either IEEE Fused-Multiply-Add (FMA) or a combination of IEEE `multiplication` and IEEE `addition` operations, depending on availability and performance of FMA instruction on the target native platform. `qfma` instructions in a WebAssembly module must execute as either all fused, or all unfused operations.
+
+### Quasi-Fused Multiply-Subtract
+* `f32x4.qfms(a: v128, b: v128, c: v128) -> v128`
+* `f64x2.qfms(a: v128, b: v128, c: v128) -> v128`
+
+Lane-wise multiplication and subtraction (`a - b * c`), either with, or without intermediate rounding. WebAssembly implementation may execute this instruction as either IEEE Fused-Multiply-Subtract (FMS) or a combination of IEEE `multiplication` and IEEE `subtraction` operations, depending on availability and performance of FMS instruction on the target native platform. `qfms` instructions in a WebAssembly module must execute as either all fused, or all unfused operations.
+
 ## Conversions
 ### Integer to floating point
 * `f32x4.convert_i32x4_s(a: v128) -> v128`


### PR DESCRIPTION
# Introduction

Most modern processors support Fused Multiply-Add (FMA) family instructions. These instructions compute multiplication and addition of floating-point numbers **without** intermediate rounding. Elimination of intermediate rounding improves accuracy in most numerical algorithms, and moreover FMA instructions provide performance improvements on all processors which support these instructions:
- Intel Haswell processors achieve 32 FLOPs/cycle with FMA, but only 16 FLOPs/cycle with separate multiply+add instructions.[1]
- AMD Piledriver and Zen processors deliver 16 FLOPs/cycle with FMA, but only 8 FLOPs/cycle with separate multiply+add instructions.[1]
- ARM Cortex-A55 and Cortex-A75 cores archieve 8 FLOPs/cycle with FMA, but only 4 FLOPs/cycle with separate multiply+add instructions.[2,3]

However, on processors which do not support FMA instructions, it is expensive to emulate these operations exactly, without intermediate rounding.

**This PR introduce Quasi-Fused Multiply-Add instruction which provides the performance and accuracy benefits of FMA, where supported, while preserving compatibility with older processors.** Quasi-Fused Multiply-Add (QFMA) instruction represents `a + b * c` with **optional** rounding after multiplication. WebAssembly implementations are required to be consistent, and either always generate FMA instruction, or always generate multiplication+addition pair for a QFMA instruction within a module. QFMA instruction is augmented by Quasi-Fused Multiply-Subtract (QFMA) instruction which represents `a - b * c` with similar optional rounding after multiplication.

# Performance Impact

Fused Multiply-Add instructions improve performance in two ways:
- They double floating-point throughput in most processors by occupying floating-point SIMD units for only one cycle, compared to two cycles for the separate multiplication + addition instructions.
- The reduce register pressure when `QFMA(a, b, c)` result overwrites operand `a`. This situation is very typical in dense linear algebra and neural network computations, and without FMA the implementation would have to allocate a temporary register `t` for the result of multiplication (`t <- b * c ; a <- a + t`).

## Evaluation on native ARM64 code

To estimate the speedup from FMA in practice, I replaced NEON FMA intrinsics (`vfmaq_f32` and `vfmaq_lane_f32`) in ARM64 implementation of neural network inference with non-fused NEON intrinsics (`vmlaq_f32` and `vmlaq_lane_f32`). Both versions were compiled with Clang to native (i.e. not WebAssembly) binaries for ARM64 architecture, and evaluated in single-threaded mode. Speedups of FMA-based version compared to version with separate multiplication + addition are presented in the table below:

Mobile phone | Xiaomi Mi A2 Lite | Pixel 2 XL | LG G8 ThinQ | Galaxy S8 (Exynos)
-- | -- | -- | -- | --
Processor core | Cortex-A53 | Cortex-A73 | Cortex-A76 | Exynos-M2
MobileNet v2 [5] | 2.05 | 2.11 | 2.14 | 1.79
Face Mesh [7] | 1.83 | 1.67 | 1.75 | 1.63
Segmentation [8] | 1.54 | 1.56 | 1.93 | 1.43

Across 3 neural network architectures and 4 mobile devices, the minimum speedup is 1.4X, and speedup on the most compute-intensive neural network (MobileNet v2) exceeds 2X. I suggest that an improvement this big justifies extending WebAssembly SIMD spec with 4 new instructions.

## [October 3 update] Evaluation of QFMA prototype in V8

@tlively implemented experimental support of QFMA instruction in LLVM & Clang ([commit](https://reviews.llvm.org/rGd0d931706146bef249a40b875fe4f09bd84e3c31)) and Binaryen ([PR](https://github.com/WebAssembly/binaryen/pull/2328)), and @ngzhian implemented QFMA lowering in V8 for x86-64 ([commit](https://chromium.googlesource.com/v8/v8/+/2cf821cc016a0249badd8a58de596b9f82e02d41)) and ARM64 ([commit](https://chromium.googlesource.com/v8/v8/+/628cc44a2978bedd97dbd6dd06aede1fb38de618)) architectures. Due to experimental nature of the prototype toolchain, it is conservative in leveraging QFMA instructions, and generates them only through an explicit intrinsic.

I ported the most critical micro-kernels in [XNNPACK](https://github.com/google/XNNPACK) neural network operator library to use QFMA, and evaluated its performance on 9 neural network models. The table below presents the results:

Host | Xeon W-2135 | Xiaomi Mi A2 Lite | Pixel 2 XL | LG G8 ThinQ | Galaxy S8 | Galaxy S10
-- | -- | -- | -- | -- | -- | --
Processor core | Sky Lake | Cortex-A53 | Cortex-A73 | Cortex-A76 | Exynos-M2 | Exynos-M4
MobileNet v1 [4] | 43% | 17% | 36% | 48% | 27% | 44% |
MobileNet v2 [5] | 38% | 14% | 27% | 36% | 21% | 35% |
SSDLite [5] | 36% | 13% | 28% | 36% | 21% | 45% |
SqueezeNet [6] | 50% | 28% | 40% | 41% | 29% | 50% |
Face Mesh [7] | 26% | 15% | 21% | 29% | 18% | 24% |
Segmentation [8] | 29% | 16% | 21% | 34% | 18% | 25% |
BlazeFace [9] | 27% | 19% | 19% | 18% | 9% | 15% |
Hand Mesh [10] | 30% | 9% | 25% | 38% | 19% | 34% |
Hand Detector [10] | 26% | 10% | 29% | 36% | 16% | 32% |
Geomean | 33% | 15% | 26% | 34% | 19% | 32% |

While the speedup from QFMA in the prototype WebAssembly implementation is smaller than in native code, QFMA improved performance on all 6 evaluated devices, and on modern CPU microarchitectures (Intel Sky Lake, ARM Cortex-A76, Samsung Exynos-M4) QFMA improves performance on average by one third.

# Mapping to Common Instruction Sets

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

### x86/x86-64 processors with FMA3 (but no FMA4) instruction set

These processors include Intel Haswell (and later) and AMD Zen (and later).

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD231PS xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFMADD231PS xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PS xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFMADD213PS xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PS xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFMADD213PS xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f32x4.qfma(a, b, c)` is lowered to one of six options:
    1. `VMOVUPS xmm_d, xmm_a + VFMADD231PS xmm_d, xmm_b, xmm_c` (`a` and `c` can be in-memory)
    2. `VMOVUPS xmm_d, xmm_a + VFMADD231PS xmm_d, xmm_c, xmm_b` (`a` and `b` can be in-memory)
    3. `VMOVUPS xmm_d, xmm_b +  VFMADD132PS xmm_d, xmm_a, xmm_c` (`b` and `c` can be in-memory)
    4. `VMOVUPS xmm_d, xmm_b + VFMADD213PS xmm_d, xmm_c, xmm_a` (`b` and `a` can be in-memory)
    5. `VMOVUPS xmm_d, xmm_c + VFMADD132PS xmm_d, xmm_a, xmm_b` (`c` and `b` can be in-memory)
    6. `VMOVUPS xmm_d, xmm_c + VFMADD213PS xmm_d, xmm_b, xmm_a` (`c` and `a` can be in-memory)
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD231PS xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFNMADD231PS xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PS xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFNMADD213PS xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PS xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFNMADD213PS xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f32x4.qfms(a, b, c)` is lowered to one of six options:
    1. `VMOVUPS xmm_d, xmm_a + VFNMADD231PS xmm_d, xmm_b, xmm_c` (`a` and `c` can be in-memory)
    2. `VMOVUPS xmm_d, xmm_a + VFNMADD231PS xmm_d, xmm_c, xmm_b` (`a` and `b` can be in-memory)
    3. `VMOVUPS xmm_d, xmm_b +  VFNMADD132PS xmm_d, xmm_a, xmm_c` (`b` and `c` can be in-memory)
    4. `VMOVUPS xmm_d, xmm_b + VFNMADD213PS xmm_d, xmm_c, xmm_a` (`b` and `a` can be in-memory)
    5. `VMOVUPS xmm_d, xmm_c + VFNMADD132PS xmm_d, xmm_a, xmm_b` (`c` and `b` can be in-memory)
    6. `VMOVUPS xmm_d, xmm_c + VFNMADD213PS xmm_d, xmm_b, xmm_a` (`c` and `a` can be in-memory)
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD231PD xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFMADD231PD xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PD xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFMADD213PD xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PD xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFMADD213PD xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f64x2.qfma(a, b, c)` is lowered to one of six options:
    1. `VMOVUPD xmm_d, xmm_a + VFMADD231PD xmm_d, xmm_b, xmm_c` (`a` and `c` can be in-memory)
    2. `VMOVUPD xmm_d, xmm_a + VFMADD231PD xmm_d, xmm_c, xmm_b` (`a` and `b` can be in-memory)
    3. `VMOVUPD xmm_d, xmm_b +  VFMADD132PD xmm_d, xmm_a, xmm_c` (`b` and `c` can be in-memory)
    4. `VMOVUPD xmm_d, xmm_b + VFMADD213PD xmm_d, xmm_c, xmm_a` (`b` and `a` can be in-memory)
    5. `VMOVUPD xmm_d, xmm_c + VFMADD132PD xmm_d, xmm_a, xmm_b` (`c` and `b` can be in-memory)
    6. `VMOVUPD xmm_d, xmm_c + VFMADD213PD xmm_d, xmm_b, xmm_a` (`c` and `a` can be in-memory)
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD231PD xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFNMADD231PD xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PD xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFNMADD213PD xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PD xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFNMADD213PD xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f64x2.qfms(a, b, c)` is lowered to one of six options:
    1. `VMOVUPD xmm_d, xmm_a + VFNMADD231PD xmm_d, xmm_b, xmm_c` (`a` and `c` can be in-memory)
    2. `VMOVUPD xmm_d, xmm_a + VFNMADD231PD xmm_d, xmm_c, xmm_b` (`a` and `b` can be in-memory)
    3. `VMOVUPD xmm_d, xmm_b +  VFNMADD132PD xmm_d, xmm_a, xmm_c` (`b` and `c` can be in-memory)
    4. `VMOVUPD xmm_d, xmm_b + VFNMADD213PD xmm_d, xmm_c, xmm_a` (`b` and `a` can be in-memory)
    5. `VMOVUPD xmm_d, xmm_c + VFNMADD132PD xmm_d, xmm_a, xmm_b` (`c` and `b` can be in-memory)
    6. `VMOVUPD xmm_d, xmm_c + VFNMADD213PD xmm_d, xmm_b, xmm_a` (`c` and `a` can be in-memory)

### x86/x86-64 processors with FMA3 and FMA4 instruction sets

These processors include AMD Piledriver, AMD Steamroller, AMD Excavator, but **not** AMD Zen.

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD231PS xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFMADD231PS xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PS xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFMADD213PS xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PS xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFMADD213PS xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADDPS xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFMADDPS xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
be in-memory)
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD231PS xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFNMADD231PS xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PS xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFNMADD213PS xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PS xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFNMADD213PS xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADDPS xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFNMADDPS xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
be in-memory)
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD231PD xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFMADD231PD xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PD xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFMADD213PD xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADD132PD xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFMADD213PD xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADDPD xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFMADDPD xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
be in-memory)
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD231PD xmm_a, xmm_b, xmm_c` (`c` can be in-memory)
    2. `VFNMADD231PD xmm_a, xmm_c, xmm_b` (`b` can be in-memory)
  - `b = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PD xmm_b, xmm_a, xmm_c` (`c` can be in-memory)
    2. `VFNMADD213PD xmm_b, xmm_c, xmm_a` (`a` can be in-memory)
  - `c = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADD132PD xmm_c, xmm_a, xmm_b` (`b` can be in-memory)
    2. `VFNMADD213PD xmm_c, xmm_b, xmm_a` (`a` can be in-memory)
  - `d = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADDPD xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFNMADDPD xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)

### x86/x86-64 processors with FMA4 (and no FMA3) instruction sets

AMD Bulldozer is the only family of such processors.

- `d = f32x4.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADDPS xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFMADDPS xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
- `d = f32x4.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADDPS xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFNMADDPS xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
- `d = f64x2.qfma(a, b, c)` is lowered to one of two options:
    1. `VFMADDPD xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFMADDPD xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)
- `d = f64x2.qfms(a, b, c)` is lowered to one of two options:
    1. `VFNMADDPD xmm_d, xmm_b, xmm_c, xmm_a` (`a` or `c` can be in-memory)
    2. `VFNMADDPD xmm_d, xmm_c, xmm_b, xmm_a` (`a` or `b` can be in-memory)

### ARM64 processors

All ARM64 application processors support SIMD with FMA

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to `FMLA Va.4S, Vb.4S, Vc.4S`
  - `d = f32x4.qfma(a, b, c)` is lowered to `MOV Vd.16B, Va.16B + FMLA Va.4S, Vb.4S, Vc.4S`
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to `FMLS Va.4S, Vb.4S, Vc.4S`
  - `d = f32x4.qfms(a, b, c)` is lowered to `MOV Vd.16B, Va.16B + FMLS Va.4S, Vb.4S, Vc.4S`
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to `FMLA Va.2D, Vb.2D, Vc.2D`
  - `d = f64x2.qfma(a, b, c)` is lowered to `MOV Vd.16B, Va.16B + FMLA Va.2D, Vb.2D, Vc.2D`
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to `FMLS Va.2D, Vb.2D, Vc.2D`
  - `d = f64x2.qfms(a, b, c)` is lowered to `MOV Vd.16B, Va.16B + FMLS Va.2D, Vb.2D, Vc.2D`

### ARMv7 processors with NEONv2 (NEON-FMA) instruction set

Most 32-bit ARM application processors support SIMD (NEON) with FMA instructions.

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to `VFMA.F32 q_a, q_b, q_c`
  - `d = f32x4.qfma(a, b, c)` is lowered to `VMOV q_d, q_a + VFMA.F32 q_d, q_b, q_c`
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to `VFMS.F32 q_a, q_b, q_c`
  - `d = f32x4.qfms(a, b, c)` is lowered to `VMOV q_d, q_a + VFMS.F32 q_d, q_b, q_c`
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to `VFMA.F64 d_a0, d_b0, d_c0 + VFMA.F64 d_a1, d_b1, d_c1`
  - `d = f64x2.qfma(a, b, c)` is lowered to `VMOV q_d, q_a + VFMA.F64 q_d0, q_b0, q_c0 + VFMA.F64 q_d1, q_b1, q_c1`
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to `VFMS.F64 d_a0, d_b0, d_c0 + VFMS.F64 d_a1, d_b1, d_c1`
  - `d = f64x2.qfms(a, b, c)` is lowered to `VMOV q_d, q_a + VFMA.F64 q_d0, q_b0, q_c0 + VFMS.F64 q_d1, q_b1, q_c1`

### ARMv7 processors with NEON (but without FMA) instruction set

ARM Cortex-A8, ARM Cortex-A9, and Qualcomm Scorpion are the only significant cores which support SIMD (NEON), but not the FMA extension

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to `VMLA.F32 q_a, q_b, q_c` (note: multiply-add **with** intermediate rounding)
  - `d = f32x4.qfma(a, b, c)` is lowered to `VMUL.F32 q_d, q_b, q_c + VADD.F32 q_d, q_a, q_d`
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to `VMLS.F32 q_a, q_b, q_c` (note: multiply-subtract **with** intermediate rounding)
  - `d = f32x4.qfms(a, b, c)` is lowered to `VMUL.F32 q_d, q_b, q_c + VSUB.F32 q_d, q_a, q_d`
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to `VMLA.F64 d_a0, d_b0, d_c0 + VMLA.F64 d_a1, d_b1, d_c1` (note: multiply-add **with** intermediate rounding)
  - `d = f64x2.qfma(a, b, c)` is lowered to `VMUL.F64 d_d0, d_b0, d_c0 + VMUL.F64 d_d1, d_b1, d_c1 + VADD.F64 d_d0, d_a0, d_d0 + VADD.F64 d_d1, d_a1, d_d1`
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to `VMLS.F64 d_a0, d_b0, d_c0 + VMLS.F64 d_a1, d_b1, d_c1` (note: multiply-subtract **with** intermediate rounding)
  - `d = f64x2.qfms(a, b, c)` is lowered to `VMUL.F64 d_d0, d_b0, d_c0 + VMUL.F64 d_d1, d_b1, d_c1 + VSUB.F64 d_d0, d_a0, d_d0 + VSUB.F64 d_d1, d_a1, d_d1`

### POWER processors with VSX instruction set

IBM POWER processors starting with POWER7

- **f32x4.qfma**
  - `a = f32x4.qfma(a, b, c)` is lowered to `XVMADDASP x_a, x_b, x_c`
  - `b = f32x4.qfma(a, b, c)` is lowered to `XVMADDMSP x_b, x_c, x_a`
  - `c = f32x4.qfma(a, b, c)` is lowered to `XVMADDMSP x_c, x_b, x_a`
  - `d = f32x4.qfma(a, b, c)` is lowered to `VMR x_d, x_a + XVMADDASP x_d, x_b, x_c`
- **f32x4.qfms**
  - `a = f32x4.qfms(a, b, c)` is lowered to `XVNMSUBASP x_a, x_b, x_c`
  - `b = f32x4.qfms(a, b, c)` is lowered to `XVNMSUBMSP x_b, x_c, x_a`
  - `c = f32x4.qfms(a, b, c)` is lowered to `XVNMSUBMSP x_c, x_b, x_a`
  - `d = f32x4.qfms(a, b, c)` is lowered to `VMR x_d, x_a + XVNMSUBASP x_d, x_b, x_c`
- **f64x2.qfma**
  - `a = f64x2.qfma(a, b, c)` is lowered to `XVMADDADP x_a, x_b, x_c`
  - `b = f64x2.qfma(a, b, c)` is lowered to `XVMADDMDP x_b, x_c, x_a`
  - `c = f64x2.qfma(a, b, c)` is lowered to `XVMADDMDP x_c, x_b, x_a`
  - `d = f64x2.qfma(a, b, c)` is lowered to `VMR x_d, x_a + XVMADDADP x_d, x_b, x_c`
- **f64x2.qfms**
  - `a = f64x2.qfms(a, b, c)` is lowered to `XVNMSUBADP x_a, x_b, x_c`
  - `b = f64x2.qfms(a, b, c)` is lowered to `XVNMSUBMDP x_b, x_c, x_a`
  - `c = f64x2.qfms(a, b, c)` is lowered to `XVNMSUBMDP x_c, x_b, x_a`
  - `d = f64x2.qfms(a, b, c)` is lowered to `VMR x_d, x_a + XVNMSUBADP x_d, x_b, x_c`

### Other processors and instruction sets

- **f32x4.qfma**
  - `d = f32x4.qfma(a, b, c)` is lowered like `d = f32x4.add(a, f32x4.mul(b, c))`
- **f32x4.qfms**
  - `d = f32x4.qfms(a, b, c)` is lowered like `d = f32x4.sub(a, f32x4.mul(b, c))`
- **f64x2.qfma**
  - `d = f64x2.qfma(a, b, c)` is lowered like `d = f64x2.add(a, f64x2.mul(b, c))`
- **f64x2.qfms**
  - `d = f64x2.qfms(a, b, c)` is lowered like `d = f64x2.sub(a, f64x2.mul(b, c))`

# References

[1] [Lists of instruction latencies, throughputs and micro-operation breakdowns for Intel, AMD
and VIA CPUs](https://www.agner.org/optimize/instruction_tables.pdf) by Agner Fog
[2] [ARM Cortex-A55 Software Optimization Guide](http://infocenter.arm.com/help/topic/com.arm.doc.epm128372/arm_cortex_a55_software_optimization_guide_v2.pdf)
[3] [ARM Cortex-A75 Software Optimization Guide](https://static.docs.arm.com/101398/0200/arm_cortex_a75_software_optimization_guide_v2.pdf)
[4] [MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications](https://arxiv.org/abs/1704.04861)
[5] [MobileNetV2: Inverted Residuals and Linear Bottlenecks](https://arxiv.org/abs/1801.04381)
[6] [SqueezeNet: AlexNet-level accuracy with 50x fewer parameters and <0.5MB model size](https://arxiv.org/abs/1602.07360)
[7] [Real-Time AR Self-Expression with Machine Learning](https://ai.googleblog.com/2019/03/real-time-ar-self-expression-with.html)
[8] [Mobile Real-time Video Segmentation](https://ai.googleblog.com/2018/03/mobile-real-time-video-segmentation.html)
[9] [BlazeFace: Sub-millisecond Neural Face Detection on Mobile GPUs](https://arxiv.org/abs/1907.05047)
[10] [On-Device, Real-Time Hand Tracking with MediaPipe](https://ai.googleblog.com/2019/08/on-device-real-time-hand-tracking-with.html)