### PR TITLE
Add Load-And-Splat instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -168,3 +168,7 @@ The `v8x16.shuffle2_imm` instruction has 16 bytes after `simdop`.
 | `f64x2.convert_u/i64x2`   |    `0xb2`| -                  |
 | `v8x16.shuffle1`          |    `0xc0`| -                  |
 | `v8x16.shuffle2_imm`      |    `0xc1`| s:LaneIdx32[16]    |
+| `i8x16.load_splat`        |    `0xc2`| -                  |
+| `i16x8.load_splat`        |    `0xc3`| -                  |
+| `i32x4.load_splat`        |    `0xc4`| -                  |
+| `i64x2.load_splat`        |    `0xc5`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -4,14 +4,17 @@
 | `v128.store`              |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.const`              | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.splat`             |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `i8x16.load_splat`        |                           |                    |                    |                    |
 | `i8x16.extract_lane_s`    |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.extract_lane_u`    | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.replace_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.splat`             |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `i16x8.load_splat`        |                           |                    |                    |                    |
 | `i16x8.extract_lane_s`    |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.extract_lane_u`    | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.replace_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.splat`             |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `i32x4.load_splat`        |                           |                    |                    |                    |
 | `i32x4.extract_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.replace_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.splat`             | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
@@ -21,6 +24,7 @@
 | `f32x4.extract_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.replace_lane`      |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.splat`             | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
+| `i64x2.load_splat`        |                           |                    |                    |                    |
 | `f64x2.extract_lane`      | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.replace_lane`      | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.eq`                |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -666,6 +666,15 @@ natural alignment.
 
 Load a `v128` vector from the given heap address.
 
+### Load and Splat
+
+* `i8x16.load_splat(memarg) -> v128`
+* `i16x8.load_splat(memarg) -> v128`
+* `i32x4.load_splat(memarg) -> v128`
+* `i64x2.load_splat(memarg) -> v128`
+
+Load a single element and splat to all lanes of a `v128` vector.
+
 ### Store
 
 * `v128.store(memarg, data: v128)`


### PR DESCRIPTION
# Introduction

Loading a single element into all lanes of a SIMD vector is a common operation in signal processing, and both ARM NEON and recent x86 SIMD extensions can do it in a single instruction. In currently WebAssembly SIMD proposal this operation can be emulated via a combination of a scalar load and a `splat` instruction to replace the loaded scalar value into all lanes of a SIMD register. Unlike LLVM, streaming compilers in WebAssembly engines generate code under tight latency constraints, and can not afford pattern matching to generate optimal machine instruction for the combination of load and splat WAsm instructions. **This PR introduce combined Load-and-Splat instructions which offer two advantages improvements over the above two-instruction combination**:
1. The value from memory is loaded directly into SIMD register rather than a general-purpose register (which store scalar integer values) in the current two-instruction scheme. Loading value directly into SIMD register **eliminates expensive transfer from general-purpose register to a SIMD register** requires in the current two-instruction scheme.
2. These instructions enable WebAssembly implementations to leverage specialized instructions to load-and-splat element which exist in both ARM and x86 SIMD extensions.

# Mapping to Common Instruction Sets
This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

## x86/x86-64 processors with AVX2 instruction set
- `v = i8x16.load_splat(mem)` maps to `VPBROADCASTB xmm_v, [mem]`
- `v = i16x8.load_splat(mem)` maps to `VPBROADCASTW xmm_v, [mem]`
- `v = i32x4.load_splat(mem)` is lowered like in AVX instruction set
- `v = i64x2.load_splat(mem)` is lowered like in AVX instruction set

## x86/x86-64 processors with AVX instruction set
- `v = i8x16.load_splat(mem)` maps to `VPINSRB xmm_v, [mem], 0 + VPXOR xmm_t, xmm_t, xmm_t + VPSHUFB xmm_v, xmm_v, xmm_t`
- `v = i16x8.load_splat(mem)` maps to `VPINSRW xmm_v, [mem], 0 + VPSHUFLW xmm_v, xmm_v, 0 + VPUNPCKLQDQ xmm_v, xmm_v, xmm_v`
- `v = i32x4.load_splat(mem)` maps to `VBROADCASTSS xmm_v, [mem]`
- `v = i64x2.load_splat(mem)` maps to `VBROADCASTSD xmm_v, [mem]`

## x86/x86-64 processors with SSE4.1 instruction set
- `v = i8x16.load_splat(mem)` maps to `PINSRB xmm_v, [mem], 0 + PXOR xmm_t, xmm_t + PSHUFB xmm_v, xmm_t`
- `v = i16x8.load_splat(mem)` is lowered like in SSE2 instruction set`
- `v = i32x4.load_splat(mem)` is lowered like in SSE2 instruction set
- `v = i64x2.load_splat(mem)` is lowered like in SSE3 instruction set

## x86/x86-64 processors with SSE3 instruction set
- `v = i8x16.load_splat(mem)` is lowered like in SSE2 instruction set
- `v = i16x8.load_splat(mem)` is lowered like in SSE2 instruction set`
- `v = i32x4.load_splat(mem)` is lowered like in SSE2 instruction set
- `v = i64x2.load_splat(mem)` maps to `MOVDDUP xmm_v, [mem]`

## x86/x86-64 processors with SSE2 instruction set
- `v = i8x16.load_splat(mem)` maps to `MOVZX r32_t, byte [mem] + IMUL r32_t, r32_t, 0x01010101 + MOVD xmm_v, r32_t + PSHUFD xmm_v, xmm_v, 0`
- `v = i16x8.load_splat(mem)` maps to `PINSRW xmm_v, [mem], 0 + PSHUFLW xmm_v, xmm_v, 0 + PUNPCKLQDQ xmm_v, xmm_v`
- `v = i32x4.load_splat(mem)` maps to `MOVSS xmm_v, [mem] + SHUFPS xmm_v, xmm_v, 0`
- `v = i64x2.load_splat(mem)` maps to `MOVSD xmm_v, [mem] + UNPCKLPD xmm_v, xmm_v`

## ARM64 processors
- `v = i8x16.load_splat(mem)` maps to `LD1R {Vv.16B}, [Rmem]`
- `v = i16x8.load_splat(mem)` maps to `LD1R {Vv.8H}, [Rmem]`
- `v = i32x4.load_splat(mem)` maps to `LD1R {Vv.4S}, [Rmem]`
- `v = i64x2.load_splat(mem)` maps to `LD1R {Vv.2D}, [Rmem]`

## ARMv7 processors with NEON instruction set
- `v = i8x16.load_splat(mem)` maps to `VLD1.8 {d_v[], d_v+1[]}, [Rmem]`
- `v = i16x8.load_splat(mem)` maps to `VLD1.16 {d_v[], d_v+1[]}, [Rmem]`
- `v = i32x4.load_splat(mem)` maps to `VLD1.32 {d_v[], d_v+1[]}, [Rmem]`
- `v = i64x2.load_splat(mem)` maps to `VLD1.64 {d_v[], d_v+1[]}, [Rmem]`
