### PR TITLE
This is to assign the opcodes for the load extend instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -172,3 +172,9 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i16x8.load_splat`        |    `0xc3`| -                  |
 | `i32x4.load_splat`        |    `0xc4`| -                  |
 | `i64x2.load_splat`        |    `0xc5`| -                  |
+| 'i8x8.sload'              |    '0xc6'| -                  |
+| 'i16x4.sload'             |    '0xc7'| -                  |
+| 'i32x2.sload'             |    '0xc8'| -                  |
+| 'i8x8.zload'              |    '0xc9'| -                  |
+| 'i16x4.zload'             |    '0xca'| -                  |
+| 'i32x2.zload'             |    '0xcb'| -                  |


### PR DESCRIPTION
This proposed change is to add the 6 load extend instructions for signed and unsigned integers using the naming convention suggested by others in the pull request https://github.com/WebAssembly/simd/issues/28