### PR TITLE
Rename load-and-splat instructions from iNxM.load_splat to vNxM.load_splat

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -168,10 +168,10 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f64x2.convert_u/i64x2`    |    `0xb2`| -                  |
 | `v8x16.swizzle`            |    `0xc0`| -                  |
 | `v8x16.shuffle`            |    `0xc1`| s:LaneIdx32[16]    |
-| `i8x16.load_splat`         |    `0xc2`| -                  |
-| `i16x8.load_splat`         |    `0xc3`| -                  |
-| `i32x4.load_splat`         |    `0xc4`| -                  |
-| `i64x2.load_splat`         |    `0xc5`| -                  |
+| `v8x16.load_splat`         |    `0xc2`| -                  |
+| `v16x8.load_splat`         |    `0xc3`| -                  |
+| `v32x4.load_splat`         |    `0xc4`| -                  |
+| `v64x2.load_splat`         |    `0xc5`| -                  |
 | `i8x16.narrow_i16x8_s`     |    `0xc6`| -                  |
 | `i8x16.narrow_i16x8_u`     |    `0xc7`| -                  |
 | `i16x8.narrow_i32x4_s`     |    `0xc8`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -4,17 +4,17 @@
 | `v128.store`               |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.const`               | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.splat`              |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i8x16.load_splat`         |                           |                    | :heavy_check_mark: |                    |
+| `v8x16.load_splat`         |                           |                    | :heavy_check_mark: |                    |
 | `i8x16.extract_lane_s`     |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.extract_lane_u`     | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.replace_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.splat`              |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i16x8.load_splat`         |                           |                    | :heavy_check_mark: |                    |
+| `v16x8.load_splat`         |                           |                    | :heavy_check_mark: |                    |
 | `i16x8.extract_lane_s`     |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.extract_lane_u`     | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.replace_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.splat`              |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i32x4.load_splat`         |                           |                    | :heavy_check_mark: |                    |
+| `v32x4.load_splat`         |                           |                    | :heavy_check_mark: |                    |
 | `i32x4.extract_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.replace_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.splat`              | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
@@ -24,7 +24,7 @@
 | `f32x4.extract_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.replace_lane`       |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.splat`              | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.load_splat`         |                           |                    | :heavy_check_mark: |                    |
+| `v64x2.load_splat`         |                           |                    | :heavy_check_mark: |                    |
 | `f64x2.extract_lane`       | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.replace_lane`       | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.eq`                 |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -668,10 +668,10 @@ Load a `v128` vector from the given heap address.
 
 ### Load and Splat
 
-* `i8x16.load_splat(memarg) -> v128`
-* `i16x8.load_splat(memarg) -> v128`
-* `i32x4.load_splat(memarg) -> v128`
-* `i64x2.load_splat(memarg) -> v128`
+* `v8x16.load_splat(memarg) -> v128`
+* `v16x8.load_splat(memarg) -> v128`
+* `v32x4.load_splat(memarg) -> v128`
+* `v64x2.load_splat(memarg) -> v128`
 
 Load a single element and splat to all lanes of a `v128` vector.
 


### PR DESCRIPTION
This is consistent with other instructions like `v8x16.swizzle` and `v8x16.shuffle` that can be defined as operating on uninterpreted bit strings rather than integers or floats.