### PR TITLE
Introduce Load and Extend

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -109,7 +109,6 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i8x16.sub`                |    `0x5a`| -                  |
 | `i8x16.sub_saturate_s`     |    `0x5b`| -                  |
 | `i8x16.sub_saturate_u`     |    `0x5c`| -                  |
-| `i8x16.mul`                |    `0x5d`| -                  |
 | `i16x8.neg`                |    `0x62`| -                  |
 | `i16x8.any_true`           |    `0x63`| -                  |
 | `i16x8.all_true`           |    `0x64`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -86,7 +86,6 @@
 | `i8x16.sub`                |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.sub_saturate_s`     |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.sub_saturate_u`     |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i8x16.mul`                |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.neg`                |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.any_true`           |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.all_true`           |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -367,7 +367,6 @@ def S.sub(a, b):
 ```
 
 ### Integer multiplication
-* `i8x16.mul(a: v128, b: v128) -> v128`
 * `i16x8.mul(a: v128, b: v128) -> v128`
 * `i32x4.mul(a: v128, b: v128) -> v128`
 


### PR DESCRIPTION
Rebasing #77 on current master and incorporating the latest review feedback.

This change proposes six new load instructions, that would combine memory read of "half-size" vector with extending each lane to the next standard lane size. Motivating workloads are machine learning, image compression, video rendering, and data processing. There is widespread hardware support. Also see #23, #28, #77

Hardware support from #23:

* `PMOVZXWD xmm, [mem]` on x86 with SSE4.1
* `MOVQ xmm, [mem] + PXOR xmm0, xmm0 + PUNPCKLWD xmm, xmm0` on SSE2
* `VLD1.16 {dX}, [rAddr] + VMOVL.U16 qX, dX` on ARMv7+NEON
* `LD1 {Vx.4H}, xAddr + UXTL Vx.4S, Vx.4H` on ARM64
