### PR TITLE
ANDNOT operation

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -189,3 +189,4 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i32x4.load16x4_u`         |    `0xd5`| m:memarg           |
 | `i64x2.load32x2_s`         |    `0xd6`| m:memarg           |
 | `i64x2.load32x2_u`         |    `0xd7`| m:memarg           |
+| `v128.andnot`              |    `0xd8`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -71,6 +71,7 @@
 | `f64x2.ge`                 | `-munimplemented-simd128` |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.not`                 |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.and`                 |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `v128.andnot`              |                           |                    |                    |                    |
 | `v128.or`                  |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.xor`                 |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.bitselect`           |               `-msimd128` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -521,6 +521,12 @@ The logical operations defined on the scalar integer types are also available
 on the `v128` type where they operate bitwise the same way C's `&`, `|`, `^`,
 and `~` operators work on an `unsigned` type.
 
+### Bitwise AND-NOT
+
+* `v128.andnot(a: v128, b: v128) -> v128`
+
+Bitwise AND of bits of `a` and the logical inverse of bits of `b`. This operation is equivalent to `v128.and(a, v128.not(b))`.
+
 ### Bitwise select
 * `v128.bitselect(v1: v128, v2: v128, c: v128) -> v128`
 


### PR DESCRIPTION
Introduction
=========

ANDNOT is a widely supported SIMD operation which computes `a & ~b`. ANDNOT is involved in a common idiom of zeroing out elements which don't satisfy a condition, i.e.

```c
float x = ...;
const bool cond = ...;
if (!cond) x = 0;
```

In the present SIMD instruction set, a vectorized version of this snippet would require two WAsm SIMD instructions, `v128.and` and `v128.not`:

```c
v128 x = ...;
const v128 cond = ...;
x = v128.and(x, v128.not(cond));
```

Representing ANDNOT as two instructions is inefficient on all architectures:

- On ARM, ARM64, and PowerPC it requires two machine instructions even though ANDNOT has an exact equivalent in their SIMD instruction sets.
- On x86 and x86-64 it requires three machine instructions because x86 SIMD extensions (until AVX512) do not include SIMD `NOT` operation. Thus, WAsm engine would typically generate three instructions: two (`PXOR tmp_zero, tmp_zero` to zero a temporary register and `PANDNOT b, tmp_zero` **(!)** to emulate `v128.not`), and an extra `PAND`.

This PR introduce combined ANDNOT instruction to enable WebAssembly engines to directly leverage architecture-specific ANDNOT instructions without doing complicated and expensive analysis of the instruction stream

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instruction can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
---------------------------------------------

- `c = v128.andnot(a, b)` maps to `VANDNPS xmm_c, xmm_b, xmm_a` (note the **inverted order of operands**)

x86/x86-64 processors with SSE instruction set
---------------------------------------------

- `c = v128.andnot(a, b)` maps to `MOVAPS xmm_c, xmm_b` + `ANDNPS xmm_c, xmm_a` (note the **inverted order of operands**)
- `b = v128.andnot(a, b)` maps to `ANDNPS xmm_b, xmm_a` (note the **inverted order of operands**)

ARMv7+ processors with NEON instruction set
---------------------------------------------

- `c = v128.andnot(a, b)` maps to `VBIC Qc, Qa, Qb`

ARM64 processors
--------------------------

- `c = v128.andnot(a, b)` maps to `BIC Vc.16B, Va.16B, Vb.16B`

POWER processors with Vector facility (VMX)
--------------------------------------

- `c = v128.andnot(a, b)` maps to `VANDC Vc, Va, Vb`
