### PR TITLE
Update 64x2 instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -132,12 +132,11 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i32x4.sub`                |    `0x7c`| -                  |
 | `i32x4.mul`                |    `0x7f`| -                  |
 | `i64x2.neg`                |    `0x84`| -                  |
-| `i64x2.any_true`           |    `0x85`| -                  |
-| `i64x2.all_true`           |    `0x86`| -                  |
 | `i64x2.shl`                |    `0x87`| -                  |
 | `i64x2.shr_s`              |    `0x88`| -                  |
 | `i64x2.shr_u`              |    `0x89`| -                  |
 | `i64x2.add`                |    `0x8a`| -                  |
+| `i64x2.mul`                |    `0x8c`| -                  |
 | `i64x2.sub`                |    `0x8d`| -                  |
 | `f32x4.abs`                |    `0x95`| -                  |
 | `f32x4.neg`                |    `0x96`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -110,13 +110,12 @@
 | `i32x4.sub`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.mul`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.neg`                | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.any_true`           | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.all_true`           | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.shl`                | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.shr_s`              | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.shr_u`              | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.add`                | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.sub`                | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
+| `i64x2.mul`                |                           |                       |                    |                    |
 | `f32x4.abs`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.sqrt`               | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -369,6 +369,7 @@ def S.sub(a, b):
 ### Integer multiplication
 * `i16x8.mul(a: v128, b: v128) -> v128`
 * `i32x4.mul(a: v128, b: v128) -> v128`
+* `i64x2.mul(a: v128, b: v128) -> v128`
 
 Lane-wise wrapping integer multiplication:
 
@@ -548,7 +549,6 @@ These operations reduce all the lanes of an integer vector to a single scalar
 * `i8x16.any_true(a: v128) -> i32`
 * `i16x8.any_true(a: v128) -> i32`
 * `i32x4.any_true(a: v128) -> i32`
-* `i64x2.any_true(a: v128) -> i32`
 
 These functions return 1 if any lane in `a` is non-zero, 0 otherwise.
 
@@ -564,7 +564,6 @@ def S.any_true(a):
 * `i8x16.all_true(a: v128) -> i32`
 * `i16x8.all_true(a: v128) -> i32`
 * `i32x4.all_true(a: v128) -> i32`
-* `i64x2.all_true(a: v128) -> i32`
 
 These functions return 1 if all lanes in `a` are non-zero, 0 otherwise.
 


### PR DESCRIPTION
A poll was held at CG meeting today, the consensus was for Option 3 of
https://github.com/WebAssembly/simd/issues/101.

This means we have all the f64x2 instructions, and some of the more
common i64x2 that have been benchmarked. This change reflects that
option in the proposal text, binary text, and implementation status.

Fixes #101.