### PR TITLE
Pseudo-Minimum and Pseudo-Maximum instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -197,6 +197,8 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `f32x4.div`                |    `0xe7`| -                  |
 | `f32x4.min`                |    `0xe8`| -                  |
 | `f32x4.max`                |    `0xe9`| -                  |
+| `f32x4.pmin`               |    `0xea`| -                  |
+| `f32x4.pmax`               |    `0xeb`| -                  |
 | `f64x2.abs`                |    `0xec`| -                  |
 | `f64x2.neg`                |    `0xed`| -                  |
 | `f64x2.sqrt`               |    `0xef`| -                  |
@@ -206,6 +208,8 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `f64x2.div`                |    `0xf3`| -                  |
 | `f64x2.min`                |    `0xf4`| -                  |
 | `f64x2.max`                |    `0xf5`| -                  |
+| `f64x2.pmin`               |    `0xf6`| -                  |
+| `f64x2.pmax`               |    `0xf7`| -                  |
 | `i32x4.trunc_sat_f32x4_s`  |    `0xf8`| -                  |
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -867,6 +867,18 @@ Lane-wise minimum value, propagating NaNs.
 
 Lane-wise maximum value, propagating NaNs.
 
+### Pseudo-minimum
+* `f32x4.pmin(a: v128, b: v128) -> v128`
+* `f64x2.pmin(a: v128, b: v128) -> v128`
+
+Lane-wise minimum value, defined as `b < a ? b : a`.
+
+### Pseudo-maximum
+* `f32x4.pmax(a: v128, b: v128) -> v128`
+* `f64x2.pmax(a: v128, b: v128) -> v128`
+
+Lane-wise maximum value, defined as `a < b ? b : a`.
+
 ## Floating-point arithmetic
 
 The floating-point arithmetic operations are all lane-wise versions of the


### PR DESCRIPTION
Introduction
========

The `f32x4.min`/`f32x4.max`/`f64x2.min`/`f64x2.max` instructions in the WebAssembly SIMD are the natural extensions of the scalar WebAssembly MVP instructions to SIMD instruction sets. These instructions follow JavaScript rules on NaN propagation, i.e. if any operand is NaN, the output is NaN. However, the `min`/`max` operations as defined in the WebAssembly specification have several drawbacks:

1. They have very **asymmetric cost across popular architectures**. E.g. while `f32x4.min` maps to a single instruction (`FMIN Vd.4S, Vn.4S, Vm.4S`) on ARM64, it doesn't have a direct or even a close equivalent in x86 instruction sets. As a result, V8 [has to use 8 SSE2 instructions](https://chromium.googlesource.com/v8/v8.git/+/refs/tags/8.0.12/src/compiler/backend/x64/code-generator-x64.cc#2549) to lower this WebAssembly instruction. 
2. **No operator or function in C or C++ defines minimum or maximum operation with the same semantic as WebAssembly.** Therefore, optimizing compilers can't generate `min`/`max` instructions from WAsm SIMD by auto-vectorizing scalar codes.
3. They **lose information**. In particular, the set of values `{ f32x4.min(a, b), f32x4.max(a, b) }` is not identically equivalent to the set of values `{ a, b }`. Consequentially, sorting networks, which underlie SIMD-friendly algorithms for sorting (e.g. [Bitonic sort](https://en.wikipedia.org/wiki/Bitonic_sorter))  and partial ordering, can't be implemented on top of `min`/`max` operations from WebAssembly SIMD.

New instructions
===========

This PR introduce Pseudo-Minimum (`f32x4.pmin` and `f64x2.pmin`) and Pseudo-Maximum (`f32x4.pmax` and `f64x2.pmax`) instructions, which implement Pseudo-Minimum and Pseudo-Maximum operations with slightly different semantics than the Minimum and Maximum in the current spec. Pseudo-Minimum is defined as `pmin(a, b) := b < a ? b : a` and Pseudo-Maximum is defined as `pmax(a, b) := a < b ? b : a`. "Pseudo" in the name refers to the fact that these operations may not return the minimum in case of signed zero inputs, in particular:
- `pmin(+0.0, -0.0) == +0.0`
- `pmax(-0.0, +0.0) == -0.0`

The new instructions fix some of the issues with WebAssembly `min`/`max` instructions:

1. They have much more uniform cost across different architectures. On x86 processors with SSE2 instruction sets, these instructions directly map to `MINPS`/`MAXPS`/`MINPD`/`MAXPD` instructions. ARM processors don't have an exact equivalent, but can implement the same operation with just two instructions. The table below compares the cost of the new `f32x4.pmin` instruction to the currently available alternatives:

Instructions | x86 with SSE2 | ARM NEON | ARM64
-- | :--: | :--: | :--:
`f32x4.min` | 8 | 1 | 1
`f32x4.bitselect(b, a, f32x4.lt(b, a))` | 4 | 2 | 2
`f32x4.pmin` | 1 | 2 | 2

2. The definition of Pseudo-Minimum and Pseudo-Maximum operations exactly match the [`std::min<T>`](https://en.cppreference.com/w/cpp/algorithm/min) and [`std::max<T>`](https://en.cppreference.com/w/cpp/algorithm/max) functions in C++ standard template library. Thus, optimizing compilers are more likely to find opportunities for auto-vectorization in existing scalar codes.
3. Pseudo-Minimum and Pseudo-Maximum operations jointly preserve information about their inputs, i.e. `{ pmin(a, b), pmax(a, b) } == { a, b }`. Thus, they are suitable for efficient implementation of sorting networks, and in particular the bitonic sort algorithm.

Mapping to Common Instruction Sets
=============================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
-----------------------------------------------

- **f32x4.pmin**
  - `y = f32x4.pmin(a, b)` is lowered to `VMINPS xmm_y, xmm_b, xmm_a`
- **f32x4.pmax**
  - `y = f32x4.pmax(a, b)` is lowered to `VMAXPS xmm_y, xmm_b, xmm_a`
- **f64x2.pmin**
  - `y = f64x2.pmin(a, b)` is lowered to `VMINPD xmm_y, xmm_b, xmm_a`
- **f64x2.pmax**
  - `y = f64x2.pmax(a, b)` is lowered to `VMAXPD xmm_y, xmm_b, xmm_a`

x86/x86-64 processors with SSE2 instruction set
-----------------------------------------------

- **f32x4.pmin**
  - `b = f32x4.pmin(a, b)` is lowered to `MINPS xmm_b, xmm_a`
  - `y = f32x4.pmin(a, b)` is lowered to `MOVAPS xmm_y, xmm_b + MINPS xmm_y, xmm_a`
- **f32x4.pmax**
  - `b = f32x4.pmax(a, b)` is lowered to `MAXPS xmm_b, xmm_a`
  - `y = f32x4.pmax(a, b)` is lowered to `MOVAPS xmm_y, xmm_b + MAXPS xmm_y, xmm_a`
- **f64x2.pmin**
  - `b = f64x2.pmin(a, b)` is lowered to `MINPD xmm_b, xmm_a`
  - `y = f64x2.pmin(a, b)` is lowered to `MOVAPD xmm_y, xmm_b + MINPD xmm_y, xmm_a`
- **f64x2.pmax**
  - `b = f64x2.pmax(a, b)` is lowered to `MAXPD xmm_b, xmm_a`
  - `y = f64x2.pmax(a, b)` is lowered to `MOVAPD xmm_y, xmm_b + MAXPD xmm_y, xmm_a`

Other processors and instruction sets
--------------------------------------------

- **f32x4.pmin**
  - `y = f32x4.pmin(a, b)` is lowered like `v128.bitselect(b, a, f32x4.lt(b, a))`
- **f32x4.pmax**
  - `y = f32x4.pmax(a, b)` is lowered like `v128.bitselect(b, a, f32x4.lt(a, b))`
- **f64x2.pmin**
  - `y = f64x2.pmin(a, b)` is lowered like `v128.bitselect(b, a, f64x2.lt(b, a))`
- **f64x2.pmax**
  - `y = f64x2.pmax(a, b)` is lowered like `v128.bitselect(b, a, f64x2.lt(a, b))`
