### PR TITLE
Sign Select instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -263,3 +263,7 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i16x8.extadd_pairwise_i8x16_u` |     `TBD`| -                        |
 | `i32x4.extadd_pairwise_i16x8_s` |     `TBD`| -                        |
 | `i32x4.extadd_pairwise_i16x8_u` |     `TBD`| -                        |
+| `v8x16.signselect`              |     `TBD`| -                        |
+| `v16x8.signselect`              |     `TBD`| -                        |
+| `v32x4.signselect`              |     `TBD`| -                        |
+| `v64x2.signselect`              |     `TBD`| -                        |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -231,6 +231,10 @@
 | `i16x8.extadd_pairwise_i8x16_u` |                           |                    |                    |                    |                    |
 | `i32x4.extadd_pairwise_i16x8_s` |                           |                    |                    |                    |                    |
 | `i32x4.extadd_pairwise_i16x8_u` |                           |                    |                    |                    |                    |
+| `v8x16.signselect`              |                           |                    |                    |                    |                    |
+| `v16x8.signselect`              |                           |                    |                    |                    |                    |
+| `v32x4.signselect`              |                           |                    |                    |                    |                    |
+| `v64x2.signselect`              |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -683,6 +683,18 @@ Note that the normal WebAssembly `select` instruction also works with vector
 types. It selects between two whole vectors controlled by a single scalar value,
 rather than selecting bits controlled by a control mask vector.
 
+### Sign select
+* `v8x16.signselect(v1: v128, v2: v128, c: v128) -> v128`
+* `v16x8.signselect(v1: v128, v2: v128, c: v128) -> v128`
+* `v32x4.signselect(v1: v128, v2: v128, c: v128) -> v128`
+* `v64x2.signselect(v1: v128, v2: v128, c: v128) -> v128`
+
+Use the sign bits in the control mask `c` to select the corresponding element
+from `v1` when 1 (negative sign) and `v2` when 0 (positive sign).
+
+Note that these instructions work for both signed integer and floating-point
+control masks.
+
 ### Lane-wise Population Count
 * `i8x16.popcnt(v: v128) -> v128`
 


### PR DESCRIPTION
Introduction
========

Piece-wise approximations with discontinuity at zero are common in numerical algorithms. Such approximations take the form `y := x < 0 ? f(x) : g(x)`. E.g. in artificial neural networks, ReLU [1], Leaky ReLU [2], Parametric ReLU [3], ELU [4], SELU [5] functions involve such piece-wise approximations. Selection between two piece-wise approximations depending on the size of input can be implemented with two WebAssembly SIMD instructions from the current specification: one instruction to replicate the highest bit of the input elements into all bits of the elements so they can be used as a bit-selection mask, and `bitselect` instruction to choose between two values, `f(x)` and `g(x)`, depending on the constructed selection mask. There are, however, two considerations which make such decomposition suboptimal in practice:

1. There are two ways to replicate the high bit of input elements: do integer comparison with zero (e.g. `i32x4.lt_s(x, v128.const(0))` for 32-bit elements) or do integer arithmetic shift right by `sizeof(element) * CHAR_BIT - 1` (e.g. `i32x4.shr_s(x, 31)` for 32-bit elements). The **optimal way to do replication depends on target architecture**: typically integer comparison is more efficient than integer shift, but if the WebAssembly engine has to explicitly instantiate `v128.const(0)`, the trade-off skews the other way. ARM NEON and ARM64 provide instructions for integer comparison with zero (e.g. `VCLT.S32 Qd, Qn, #0`/`CMLT  Vd.4S, Vn.4S, #0` for 32-bit elements), but on x86 comparison with zero would always require two instructions and an extra register, so arithmetic shift right (e.g. `PSRAD xmm_x, 31` is often preferable).
2. Since SSE4.1, x86 processors provide `PBLENDVB`/`BLENDVPS`/`BLENDVPD` instructions which choose between two vectors of 8-/32-/64-bit elements depending on the sign of elements in the selection mask. In lieu of WebAssembly instructions that directly map to these SSE4.1 instructions, **WebAssembly SIMD engines have to generate 4-5 instructions** (1-2 to construct bit mask, and 3 to emulate `v128.bitselect`) **where 1 would suffice**.

To enable efficient implementation of piece-wise approximations with discontinuity at zero, this PR introduce new Sign Select instructions which select between elements of two input vectors depending on sign of the elements in the mask vector.

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to `VPBLENDVB xmm_y, xmm_v2, xmm_v1, xmm_c`
- **v16x8.signselect**
  - `y = v16x8.signselect(v1, v2, c)` is lowered to `VPSRAW xmm_tmp, xmm_c, 15 + VPBLENDVB xmm_y, xmm_v2, xmm_v1, xmm_tmp`
- **v32x4.signselect**
  - `y = v32x4.signselect(v1, v2, c)` is lowered to `VBLENDVPS xmm_y, xmm_v2, xmm_v1, xmm_c`
- **v64x2.signselect**
  - `y = v64x2.signselect(v1, v2, c)` is lowered to `VBLENDVPD xmm_y, xmm_v2, xmm_v1, xmm_c`

x86/x86-64 processors with SSE4.1 instruction set
--------------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to:
    - `MOVDQA xmm0, xmm_c`
    - `MOVDQA xmm_y, xmm_v2`
    - `PBLENDVB xmm_y, xmm_v1 [implicit xmm0 input]`
- **v16x8.signselect**
  - `y = v16x8.signselect(v1, v2, c)` is lowered to:
    - `PXOR xmm0, xmm0`
    - `PCMPGTW xmm0, xmm_c`
    - `MOVDQA xmm_y, xmm_v2`
    - `PBLENDVB xmm_y, xmm_v1 [implicit xmm0 input]`
- **v32x4.signselect**
  - `y = v32x4.signselect(v1, v2, c)` is lowered to:
    - `MOVAPS xmm0, xmm_c`
    - `MOVAPS xmm_y, xmm_v2`
    - `BLENDVPS xmm_y, xmm_v1 [implicit xmm0 input]`
- **v64x2.signselect**
  - `y = v64x2.signselect(v1, v2, c)` is lowered to:
    - `MOVAPD xmm0, xmm_c`
    - `MOVAPD xmm_y, xmm_v2`
    - `BLENDVPD xmm_y, xmm_v1 [implicit xmm0 input]`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to:
    - `PXOR xmm_tmp, xmm_tmp`
    - `PCMPGTB xmm_tmp, xmm_c`
    - `MOVDQA xmm_y, xmm_v1`
    - `PAND xmm_y, xmm_tmp`
    - `PANDNOT xmm_tmp, xmm_v2`
    - `POR xmm_y, xmm_tmp`
- **v16x8.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to:
    - `PXOR xmm_tmp, xmm_tmp`
    - `PCMPGTW xmm_tmp, xmm_c`
    - `MOVDQA xmm_y, xmm_v1`
    - `PAND xmm_y, xmm_tmp`
    - `PANDNOT xmm_tmp, xmm_v2`
    - `POR xmm_y, xmm_tmp`
- **v32x4.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to:
    - `PXOR xmm_tmp, xmm_tmp`
    - `PCMPGTD xmm_tmp, xmm_c`
    - `MOVDQA xmm_y, xmm_v1`
    - `PAND xmm_y, xmm_tmp`
    - `PANDNOT xmm_tmp, xmm_v2`
    - `POR xmm_y, xmm_tmp`
- **v64x2.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to:
    - `PXOR xmm_tmp, xmm_tmp`
    - `PCMPGTD xmm_tmp, xmm_c`
    - `PSHUFD xmm_tmp, xmm_tmp, 0xF5`
    - `MOVDQA xmm_y, xmm_v1`
    - `PAND xmm_y, xmm_tmp`
    - `PANDNOT xmm_tmp, xmm_v2`
    - `POR xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to `CMLT Vy.16B, Vc.16B, #0 + BSL Vy.16B, Vv1.16B, Vv2.16B`
- **v16x8.signselect**
  - `y = v16x8.signselect(v1, v2, c)` is lowered to `CMLT Vy.8H, Vc.8H, #0 + BSL Vy.16B, Vv1.16B, Vv2.16B`
- **v32x4.signselect**
  - `y = v32x4.signselect(v1, v2, c)` is lowered to `CMLT Vy.4S, Vc.4S, #0 + BSL Vy.16B, Vv1.16B, Vv2.16B`
- **v64x2.signselect**
  - `y = v64x2.signselect(v1, v2, c)` is lowered to `CMLT Vy.2D, Vc.2D, #0 + BSL Vy.16B, Vv1.16B, Vv2.16B`

ARMv7 processors with NEON extension
--------------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered to `VCLT.S8 Qy, Qc, #0 + VBSL Qy.16B, Qv1.16B, Qv2.16B`
- **v16x8.signselect**
  - `y = v16x8.signselect(v1, v2, c)` is lowered to `VCLT.S16 Qy, Qc, #0 + VBSL Qy.16B, Qv1.16B, Qv2.16B`
- **v32x4.signselect**
  - `y = v32x4.signselect(v1, v2, c)` is lowered to `VCLT.S32 Qy, Qc, #0 + VBSL Qy.16B, Qv1.16B, Qv2.16B`
- **v64x2.signselect**
  - `y = v64x2.signselect(v1, v2, c)` is lowered to `VSHR.S64 Qy, Qc, #63 + VBSL Qy.16B, Qv1.16B, Qv2.16B`

Other processors and instruction sets
--------------------------------------------

- **v8x16.signselect**
  - `y = v8x16.signselect(v1, v2, c)` is lowered as either `v128.bitselect(v1, v2, i8x16.lt_s(c, v128.const(0)))` or `v128.bitselect(v1, v2, i8x16.shr_s(c, 7))`
- **v16x8.signselect**
  - `y = v16x8.signselect(v1, v2, c)` is lowered as either `v128.bitselect(v1, v2, i16x8.lt_s(c, v128.const(0)))` or `v128.bitselect(v1, v2, i16x8.shr_s(c, 15))`
- **v32x4.signselect**
  - `y = v32x4.signselect(v1, v2, c)` is lowered as either `v128.bitselect(v1, v2, i32x4.lt_s(c, v128.const(0)))` or `v128.bitselect(v1, v2, i32x4.shr_s(c, 31))`
- **v64x2.signselect**
  - `y = v64x2.signselect(v1, v2, c)` is lowered as either `v128.bitselect(v1, v2, i64x2.lt_s(c, v128.const(0)))` or `v128.bitselect(v1, v2, i64x2.shr_s(c, 63))`

References
========

[1] V. Nair and G. E. Hinton. Rectified linear units improve restricted Boltzmann machines. In Proc. 27th International Conference on Machine Learning, 2010.
[2] Maas, A. L., Hannun, A. Y., and Ng, A. Y. (2013). Rectifier nonlinearities improve neural network
acoustic models. In International Conference on Machine Learning (ICML).
[3] He, K., Zhang, X., Ren, S., and Sun, J. Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification. ArXiv e-prints, February 2015.
[4] D. Clevert, T. Unterthiner, and S. Hochreiter. Fast and accurate deep network learning by exponential linear units (ELUs). CoRR, abs/1511.07289.
[5] Klambauer, G., Unterthiner, T., Mayr, A., and Hochreiter, S. (2017). Self-Normalizing Neural
Networks. ArXiv e-prints.