### PR TITLE
Rounding Average instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -201,3 +201,5 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i64x2.load32x2_s`         |    `0xd6`| m:memarg           |
 | `i64x2.load32x2_u`         |    `0xd7`| m:memarg           |
 | `v128.andnot`              |    `0xd8`| -                  |
+| `i8x16.avgr_u`             |    `0xd9`|                    |
+| `i16x8.avgr_u`             |    `0xda`|                    |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -91,6 +91,7 @@
 | `i8x16.min_u`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
 | `i8x16.max_s`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
 | `i8x16.max_u`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
+| `i8x16.avgr_u`             |                           |                       |                    |                    |
 | `i16x8.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.any_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.all_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -108,6 +109,7 @@
 | `i16x8.min_u`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
 | `i16x8.max_s`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
 | `i16x8.max_u`              | `-munimplemented-simd128` |    :heavy_check_mark: |                    |                    |
+| `i16x8.avgr_u`             |                           |                       |                    |                    |
 | `i32x4.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.any_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.all_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -488,6 +488,21 @@ each pair.
 def S.max(a, b):
     return S.lanewise_binary(max, a, b)
 ```
+
+### Lane-wise integer rounding average
+* `i8x16.avgr_u(a: v128, b: v128) -> v128`
+* `i16x8.avgr_u(a: v128, b: v128) -> v128`
+
+Lane-wise rounding average:
+
+```python
+def S.RoundingAverage(x, y):
+    return (x + y + 1) // 2
+
+def S.avgr_u(a, b):
+    return S.lanewise_binary(S.RoundingAverage, S.AsUnsigned(a), S.AsUnsigned(b))
+```
+
 ## Bit shifts
 
 ### Left shift by scalar


### PR DESCRIPTION
Introduction
=========

Rounding Average of two integer inputs, defined as `avg(a, b) := (a + b + 1) >> 1`, is a common operation in fixed-point numerical algorithms, such as video- and audio-codecs, and image filtering. Direct implementation of Rounding Average in SIMD instruction sets following the formula `(a + b + 1) >> 1` is tricky, because while the sum `a + b + 1` can overflow the datatype of inputs, the final result always fits into the same datatype. To avoid the expensive work-around of computing `a + b + 1` in higher precision (e.g. extending inputs from 8-bit elements to 16-bit elements for the computation), all common SIMD instruction sets provide some forms of Rounding Average instructions.

This PR introduce two new WebAssembly instructions for Rounding Average operations, `i8x16.avgr_u` and `i16x8.avgr_u`, which operate on vectors of unsigned 8-bit and unsigned 16-bit integers accordingly. These instructions match the universally supported across x86, ARM, and POWER forms of the Rounding Average operation.

[October 31 update] Applications
========================

Below are examples of optimized libraries using close equivalents of the proposed `i8x16.avgr_u` and `i16x8.avgr_u` instructions:

- [Pixel prediction from motion compensation in VPX library](https://github.com/webmproject/libvpx/blob/a5d499e16570d00d5e1348b1c7977ced7af3670f/vpx_dsp/x86/avg_pred_sse2.c#L28)
- [Pixel prediction intra-frame in VPX library](https://github.com/webmproject/libvpx/blob/e7cf9fd4446ed93ca91e18b5440f1f005a5228a9/vpx_dsp/x86/highbd_intrapred_intrin_sse2.c#L390-L393)
- [Subpixel filtration in VPX library](https://github.com/webmproject/libvpx/blob/a5d499e16570d00d5e1348b1c7977ced7af3670f/vpx_dsp/x86/vpx_subpixel_8t_intrin_avx2.c#L261-L263)
- [Deblocking in x264 encoder](https://code.videolan.org/videolan/x264/blob/master/common/x86/deblock-a.asm#L1175-1179)
- [Motion compensation in x264 encoder](https://code.videolan.org/videolan/x264/blob/master/common/x86/mc-a.asm#L720-726)
- [Pixel prediction in libpng library](https://github.com/glennrp/libpng/blob/libpng16/intel/filter_sse2_intrinsics.c#L134)
- [Blending in FFmpeg library](https://github.com/FFmpeg/FFmpeg/blob/a0ac49e38ee1d1011c394d7be67d0f08b2281526/libavfilter/x86/vf_blend.asm#L197)
- [Motion Compensation in libmpeg2 library](https://github.com/zhenghuadai/matrixseer/blob/e90a28b93274ea7cd06c21e40cddf2c1d24dbb31/src/mpeg/libmpeg2/motion_comp_sse2.c#L100-L101)
- [Blending in AV1 video codec](https://github.com/mozilla/aom/blob/c8b38b0bfd36306f1886375d98512d792ffe9517/aom_dsp/x86/blend_a64_mask_sse4.c#L192-L193)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i8x16.avgr_u**
  - `y = i8x16.avgr_u(a, b)` is lowered to `VPAVGB xmm_y, xmm_a, xmm_b`
- **i16x8.avgr_u**
  - `y = i16x8.avgr_u(a, b)` is lowered to `VPAVGW xmm_y, xmm_a, xmm_b`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **i8x16.avgr_u**
  - `a = i8x16.avgr_u(a, b)` is lowered to `PAVGB xmm_a, xmm_b`
  - `y = i8x16.avgr_u(a, b)` is lowered to `MOVDQA xmm_y, xmm_a + PAVGB xmm_y, xmm_b`
- **i16x8.avgr_u**
  - `a = i16x8.avgr_u(a, b)` is lowered to `PAVGW xmm_a, xmm_b`
  - `y = i16x8.avgr_u(a, b)` is lowered to `MOVDQA xmm_y, xmm_a + PAVGW xmm_y, xmm_b`

ARM64 processors
--------------------------------------------------

- **i8x16.avgr_u**
  - `y = i8x16.avgr_u(a, b)` is lowered to `URHADD Vy.16B, Va.16B, Vb.16B`
- **i16x8.avgr_u**
  - `y = i16x8.avgr_u(a, b)` is lowered to `URHADD Vy.8H, Va.8H, Vb.8H`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **i8x16.avgr_u**
  - `y = i8x16.avgr_u(a, b)` is lowered to `VRHADD.U8 Qy, Qa, Qb`
- **i16x8.avgr_u**
  - `y = i16x8.avgr_u(a, b)` is lowered to `VRHADD.U16 Qy, Qa, Qb`

POWER processors with VMX (Altivec) instruction set
--------------------------------------------------

- **i8x16.avgr_u**
  - `y = i8x16.avgr_u(a, b)` is lowered to `VAVGUB VRy, VRa, VRb`
- **i16x8.avgr_u**
  - `y = i16x8.avgr_u(a, b)` is lowered to `VAVGUH VRy, VRa, VRb`

MIPS processors with MSA instruction set
--------------------------------------------------

- **i8x16.avgr_u**
  - `y = i8x16.avgr_u(a, b)` is lowered to `AVER_U.B Wy, Wa, Wb`
- **i16x8.avgr_u**
  - `y = i16x8.avgr_u(a, b)` is lowered to `AVER_U.H Wy, Wa, Wb`