### PR TITLE
i32x4.dot_i16x8_s instruction

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -181,6 +181,7 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.min_u`              |    `0xb7`| -                  |
 | `i32x4.max_s`              |    `0xb8`| -                  |
 | `i32x4.max_u`              |    `0xb9`| -                  |
+| `i32x4.dot_i16x8_s`        |    `0xba`| -                  |
 | `i64x2.neg`                |    `0xc1`| -                  |
 | `i64x2.shl`                |    `0xcb`| -                  |
 | `i64x2.shr_s`              |    `0xcc`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -149,6 +149,8 @@
 | `i32x4.min_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i32x4.dot_i16x8_s`        |                           |                    |                    |                    |                    |
+| `i32x4.dot_i16x8_add_s`    |                           |                    |                    |                    |                    |
 | `i64x2.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shl`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shr_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -150,7 +150,6 @@
 | `i32x4.max_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.dot_i16x8_s`        |                           |                    |                    |                    |                    |
-| `i32x4.dot_i16x8_add_s`    |                           |                    |                    |                    |                    |
 | `i64x2.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shl`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shr_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -98,13 +98,13 @@
 | i8x16.sub            | 0x71   | i16x8.sub                | 0x91   | i32x4.sub                | 0xb1   | i64x2.sub   | 0xd1   |
 | i8x16.sub_sat_s      | 0x72   | i16x8.sub_sat_s          | 0x92   | ---- sub_sat ----        | 0xb2   | ----        | 0xd2   |
 | i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | ----        | 0xd3   |
-| ---- dot ----        | 0x74   | ---- dot ----            | 0x94   | ---- dot ----            | 0xb4   | ----        | 0xd4   |
+| -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | ----        | 0xd4   |
 | ---- mul ----        | 0x75   | i16x8.mul                | 0x95   | i32x4.mul                | 0xb5   | i64x2.mul   | 0xd5   |
 | i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | ----        | 0xd6   |
 | i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | ----        | 0xd7   |
 | i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | ----        | 0xd8   |
 | i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | ----        | 0xd9   |
-| ---- avgr_s ----     | 0x7a   | ---- avgr_s ----         | 0x9a   | ---- avgr_s ----         | 0xba   | ----        | 0xda   |
+| ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | ----        | 0xda   |
 | i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | ----        | 0xdb   |
 
 | f32x4 Op        | opcode | f64x2 Op        | opcode |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -395,6 +395,11 @@ def S.mul(a, b):
     return S.lanewise_binary(mul, a, b)
 ```
 
+### Integer dot product
+* `i32x4.dot_i16x8_s(a: v128, b: v128) -> v128`
+
+Lane-wise multiply signed 16-bit integers in the two input vectors and add adjacent pairs of the full 32-bit results.
+
 ### Integer negation
 * `i8x16.neg(a: v128) -> v128`
 * `i16x8.neg(a: v128) -> v128`


### PR DESCRIPTION
Introduction
=========

Integer arithmetic instructions in WebAssembly SIMD produce results of the same element type as their inputs. To avoid overflow, developers have to pre-extend inputs to wider element types and do (twice more) arithmetic operations on twice wider elements. The need to use this work-around is particularly concerning for multiplications:

- Unlike additions and subtractions, where overflow is an exceptional situation, multiplications normally produce twice wider result than their inputs, and overflowing input type is a common, rather than exceptional, case. Thus nearly every multiplication must be accompanied by pre-extending inputs to wider element types.
- Both on x86 and on ARM, multiplications which produce twice wider results are cheaper (typically by 2x) than multiplications on the wider type itself. The table below quantifies the throughput cost (from [1]) of a combination of `PMULLW` + `PMULHW` instructions (which together compute 32-bit products of 8 16-bit inputs) and a combination of two `PMULLD` instructions (which together compute 32-bit products of 8 32-bit inputs) on various x86 microarchitectures:

Microarchitecture | 2x `PMULLD xmm, xmm` | `PMULLW xmm, xmm` + `PMULHW xmm, xmm` |
-- | :--: | :--: |
AMD Piledriver | 4 | 2 |
AMD Zen | 4 | 2 |
Intel Nehalem | 4 | 2 |
Intel Sandy Bridge | 2 | 2 |
Intel Haswell | 4 | 2 |
Intel Skylake | 2 | 1 |
Intel Goldmont | 4 | 2 |

Operations that produce twice wider results would need to return two SIMD vectors, and thus depend on the future multi-value proposal. To stay within baseline WebAssembly features, we have to aggregate the two wide results into one, so the instruction can produce a single output vector. Luckily, there is an aggregating operation directly supported in x86, MIPS, and POWER instruction sets, that can also be efficiently lowered on ARM and ARM64: addition of adjacent multiplication results. The resulting combination of a full multiplication and addition of adjacent products can be interpreted as a dot product of 2-wide subvectors within a SIMD vector, producing twice wider results than input vectors (albeit twice fewer result elements than input elements). 

This PR introduce the 2-element dot product instructions with signed 16-bit integer input elements and signed 32-bit integer output elements. We don't consider other data types, because they can't be efficiently expressed on x86 (e.g. the only multiplication on byte inputs on x86 multiplies signed bytes by unsigned bytes with signed saturation - too exotic to build a portable instruction on top of it). The new `i32x4.dot_i16x8_s` instruction returns the dot product right away, and `i32x4.dot_i16x8_add_s` additionally accumulates it with a third input vector of 32-bit elements. This second instruction was added because accumulation of dot product results is common, and many instruction sets provide a specialized instruction for this case.

[October 31 update] Applications
===========================

Below are examples of optimized libraries using close equivalents of the proposed `i32x4.dot_i16x8_s` and `i32x4.dot_i16x8_add_s` instructions:
- [Discrete Cosine Transform in libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/9a51a87af33026a2befb5abd1fdcd3362286b3dc/simd/x86_64/jfdctint-sse2.asm#L236-L239)
- [Free Lossless Audio Codec](https://github.com/xiph/flac/blob/1b5c09e4c692e243239945be3cba3ec72ea1699f/src/libFLAC/lpc_intrin_sse2.c#L83-L94)
- [Discrete Cosine Transform in VP9 video codec](https://github.com/InteractiviteVideoEtSystemes/libvpx/blob/873e38b72d4910cf59fb6930668930cca0a7dde0/vp9/encoder/x86/vp9_dct_intrin_sse2.c#L89-L97)
- [Sum of Squares in VP9 video codec](https://github.com/InteractiviteVideoEtSystemes/libvpx/blob/5183107cd4762e4834cbee1d3d77e80a0f86ae22/vpx_dsp/x86/sum_squares_sse2.c#L64-L79)
- [Subpixel filtering in VP9 video codec](https://github.com/InteractiviteVideoEtSystemes/libvpx/blob/5183107cd4762e4834cbee1d3d77e80a0f86ae22/vpx_dsp/x86/vpx_subpixel_4t_intrin_sse2.c#L727-L735)
- [(DCT?) Tranformation in SVT-HEVC video codec](https://github.com/OpenVisualCloud/SVT-HEVC/blob/master/Source/Lib/ASM_SSSE3/EbTransforms_Intrinsic_SSSE3.c#L268-L286)
- [Discrete Cosine Transform in de265 video codec](https://github.com/strukturag/libde265/blob/b500546cc40649b9786f4f258ffe3829f1bd59cd/libde265/x86/sse-dct.cc#L364-L369)
- [Sum of Squares in MJPEGTools library](https://github.com/sergiomb2/mjpegtools/blob/01a8142be246e4f4625922845d994462a732f282/utils/altivec/sumsq.c#L244)
- [Discrete Cosine Transform in MJPEGTools library](https://github.com/sergiomb2/mjpegtools/blob/01a8142be246e4f4625922845d994462a732f282/utils/altivec/field_dct_best.c#L132-L135)
- [Discrete Cosine Transform in VPX library](https://github.com/extware/libvpx/blob/802569640731033bd649c2d3b0f065a0ff674010/vpx_dsp/ppc/inv_txfm_vsx.c#L1244-L1248)
- [Packing Matrices for Matrix-Matrix Multiplication in gemmlowp library](https://github.com/google/gemmlowp/blob/6c8f5d41aa27aec992bcb75e1279a4bcea5ba6ea/internal/pack_sse.h#L97-L113)
- [Integer Matrix-Matrix Multiplication in QNNPACK library](https://github.com/pytorch/QNNPACK/blob/901e9d40aeedb2c1b212b28f022fb099ffe617c2/src/q8gemm/4x4c2-sse2.c#L64-L108)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX512VNNI and AVX512VL instruction sets
--------------------------------------------------

- **i32x4.dot_i16x8_add_s**
  - `c = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `VPDPWSSD xmm_c, xmm_a, xmm_b`
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `VMOVDQA xmm_y, xmm_c + VPDPWSSD xmm_c, xmm_a, xmm_b`

x86/x86-64 processors with XOP instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_add_s**
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `VPMADCSWD xmm_y, xmm_a, xmm_b, xmm_c`

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to `VPMADDWD xmm_y, xmm_a, xmm_b`
- **i32x4.dot_i16x8_add_s**
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `VPMADDWD xmm_tmp, xmm_a, xmm_b + VPADDD xmm_y, xmm_tmp, xmm_c`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `a = i32x4.dot_i16x8_s(a, b)` is lowered to `PMADDWD xmm_a, xmm_b`
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to `MOVDQA xmm_y, xmm_a + PMADDWD xmm_y, xmm_b`
- **i32x4.dot_i16x8_add_s**
  - `c = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `MOVDQA xmm_tmp, xmm_a + PMADDWD xmm_tmp, xmm_b + PADDD xmm_c, xmm_tmp`
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `MOVDQA xmm_y, xmm_a + PMADDWD xmm_y, xmm_b + PADDD xmm_y, xmm_c`

ARM64 processors
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to:
    - `SMULL Vtmp.4S, Va.4H, Vb.4H`
    - `SMULL2 Vtmp2.4S, Va.8H, Vb.8H`
    - `ADDP Vy.4S, Vtmp.4S, Vtmp2.4S `
- **i32x4.dot_i16x8_add_s**
  - `y = i32x4.dot_i16x8_add_s(a, b)` is lowered to:
    - `SMULL Vtmp.4S, Va.4H, Vb.4H`
    - `SMULL2 Vtmp2.4S, Va.8H, Vb.8H`
    - `ADDP Vtmp.4S, Vtmp.4S, Vtmp2.4S `
    - `ADD Vy.4S, Vy.4S, Vtmp.4S`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to:
    - `VMULL.S16 Qtmp, Da_lo, Vb_lo`
    - `VMULL.S16 Qtmp2, Da_hi, Db_hi`
    - `VPADD.I32 Dy_lo, Dtmp_lo, Dtmp_hi`
    - `VPADD.I32 Dy_hi, Dtmp2_lo, Dtmp2_hi`
- **i32x4.dot_i16x8_add_s**
  - `y = i32x4.dot_i16x8_add_s(a, b)` is lowered to:
    - `VMULL.S16 Qtmp, Da_lo, Vb_lo`
    - `VMULL.S16 Qtmp2, Da_hi, Db_hi`
    - `VPADD.I32 Dtmp_lo, Dtmp_lo, Dtmp_hi`
    - `VPADD.I32 Dtmp_hi, Dtmp2_lo, Dtmp2_hi`
    - `VADD.I32 Qy, Qy, Qtmp`

POWER processors with VMX (Altivec) instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to `VXOR VRy, VRy, VRy + VMSUMSHM VRy, VRa, VRb, VRy`
- **i32x4.dot_i16x8_add_s**
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `VMSUMSHM VRy, VRa, VRb, VRc`

MIPS processors with MSA instruction set
--------------------------------------------------

- **i32x4.dot_i16x8_s**
  - `y = i32x4.dot_i16x8_s(a, b)` is lowered to `DOTP_S.W Wy, Wa, Wb`
- **i32x4.dot_i16x8_add_s**
  - `c = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `DPADD_S.W Wc, Wa, Wb`
  - `y = i32x4.dot_i16x8_add_s(a, b, c)` is lowered to `MOVE.V Wy, Wc + DPADD_S.W Wy, Wa, Wb`

References
=========

[1] Fog, A. "Instruction tables (2019)." URL: [www.agner.org/optimize/instruction_tables.pdf](http://www.agner.org/optimize/instruction_tables.pdf).