### PR TITLE
Integer absolute value instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -199,3 +199,6 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `v128.andnot`              |    `0xd8`| -                  |
 | `i8x16.avgr_u`             |    `0xd9`|                    |
 | `i16x8.avgr_u`             |    `0xda`|                    |
+| `i8x16.abs`                |    `0xe1`| -                  |
+| `i16x8.abs`                |    `0xe2`| -                  |
+| `i32x4.abs`                |    `0xe3`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -92,6 +92,7 @@
 | `i8x16.max_s`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i8x16.max_u`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i8x16.avgr_u`             |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i8x16.abs`                |                           |                       |                    |                    |
 | `i16x8.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.any_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.all_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -110,6 +111,7 @@
 | `i16x8.max_s`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i16x8.max_u`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i16x8.avgr_u`             |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i16x8.abs`                |                           |                       |                    |                    |
 | `i32x4.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.any_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.all_true`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -123,6 +125,7 @@
 | `i32x4.min_u`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i32x4.max_s`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i32x4.max_u`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i32x4.abs`                |                           |                       |                    |                    |
 | `i64x2.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.shl`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.shr_s`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -503,6 +503,18 @@ def S.avgr_u(a, b):
     return S.lanewise_binary(S.RoundingAverage, S.AsUnsigned(a), S.AsUnsigned(b))
 ```
 
+### Lane-wise integer absolute value
+* `i8x16.abs(a: v128) -> v128`
+* `i16x8.abs(a: v128) -> v128`
+* `i32x4.abs(a: v128) -> v128`
+
+Lane-wise wrapping absolute value.
+
+```python
+def S.abs(a):
+    return S.lanewise_unary(abs, S.AsSigned(a))
+```
+
 ## Bit shifts
 
 ### Left shift by scalar
@@ -791,7 +803,7 @@ def S.neg(a):
     return S.lanewise_unary(ieee.negate, a)
 ```
 
-### Absolute value
+### Floating-point absolute value
 * `f32x4.abs(a: v128) -> v128`
 * `f64x2.abs(a: v128) -> v128`
 


### PR DESCRIPTION
Introduction
=========

Integer absolute value instructions are well-supported on the most popular architecture (on x86 since SSSE3, on ARM since the first version of NEON), and naturally complement floating-point absolute value instructions already existing in WebAssembly SIMD.

This PR introduce three new WebAssembly instructions for integer absolute value operations, `i8x16.abs`, `i16x8.abs`, and `i32x4.abs`, which operate on vectors of 8-bit, 16-bit, and 32-bit integers accordingly. 64-bit version is omitted due to lack of support in common SIMD instruction sets.

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `VPABSB xmm_y, xmm_x`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `VPABSW xmm_y, xmm_x`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `VPABSD xmm_y, xmm_x`

x86/x86-64 processors with SSSE3 instruction set
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `PABSB xmm_y, xmm_x`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `PABSW xmm_y, xmm_x`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `PABSD xmm_y, xmm_x`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **i8x16.abs**
  - `x = i8x16.abs(x)` is lowered to `PXOR xmm_tmp, xmm_tmp + PSUBB xmm_tmp, xmm_x + PMINUB xmm_x, xmm_tmp`
  - `y = i8x16.abs(x)` is lowered to `PXOR xmm_y, xmm_y + PSUBB xmm_y, xmm_x + PMINUB xmm_y, xmm_x`
- **i16x8.abs**
  - `x = i16x8.abs(x)` is lowered to `PXOR xmm_tmp, xmm_tmp + PSUBW xmm_tmp, xmm_x + PMAXSW xmm_x, xmm_tmp`
  - `y = i16x8.abs(x)` is lowered to `PXOR xmm_y, xmm_y + PSUBW xmm_y, xmm_x + PMAXSW xmm_y, xmm_x`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to:
    - `PXOR xmm_tmp, xmm_tmp`
    - `PCMPGT xmm_tmp, xmm_x`
    - `MOVDQA xmm_y, xmm_x`
    - `PSUBD xmm_y, xmm_tmp`
    - `PXOR xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `ABS Vy.16B, Vx.16B`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `ABS Vy.8H, Vx.8H`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `ABS Vy.4S, Vx.4S`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `VABS.S8 Qy, Qx`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `VABS.S16 Qy, Qx`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `VABS.S32 Qy, Qx`

POWER processors with VMX (Altivec) instruction set
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `VXOR VRtmp, VRtmp, VRtmp + VSUBUBM VRtmp, VRtmp, VRx + VMAXSB VRy, VRx, VRtmp`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `VXOR VRtmp, VRtmp, VRtmp + VSUBUHM VRtmp, VRtmp, VRx + VMAXSH VRy, VRx, VRtmp`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `VXOR VRtmp, VRtmp, VRtmp + VSUBUWM VRtmp, VRtmp, VRx + VMAXSW VRy, VRx, VRtmp`

MIPS processors with MSA instruction set
--------------------------------------------------

- **i8x16.abs**
  - `y = i8x16.abs(x)` is lowered to `LDI.B Wtmp, 0 + ASUB_S.B Wy, Wx, Wtmp`
- **i16x8.abs**
  - `y = i16x8.abs(x)` is lowered to `LDI.H Wtmp, 0 + ASUB_S.H Wy, Wx, Wtmp`
- **i32x4.abs**
  - `y = i32x4.abs(x)` is lowered to `LDI.W Wtmp, 0 + ASUB_S.W Wy, Wx, Wtmp`
