### PR TITLE
[test] Sync tests from WAVM#223

### DIFF
--- a/test/core/simd/meta/simd.py
+++ b/test/core/simd/meta/simd.py
@@ -9,66 +9,66 @@ currently only supports generating v128 const constant data.
 class SIMD(object):
 
     # Constant template
-    CONST = '({}.const {})'
+    CONST = '({value_type}.const {value})'
 
     # v128 Constant template
-    V128_CONST = '(v128.const {} {})'
+    V128_CONST = '(v128.const {lane_type} {value})'
 
-    def const(self, val, lane_type):
+    def const(self, value, value_type):
         """
         generation constant data, [e.g. i32, i64, f32, f64]
         Params:
-            val: constant data, string or list,
+            value: constant data, string or list,
             lane_type: lane type, [i32, i64, f32, f64]
         """
-        return self.CONST.format(lane_type, ''.join(val))
+        return self.CONST.format(value_type=value_type, value=''.join(value))
 
-    def v128_const(self, val, lane_type):
+    def v128_const(self, value, lane_type):
         """
         generation v128 constant data, [e.g. i8x16, i16x8, i32x4, f32x4]
         Params:
-            val: constant data, string or list,
+            value: constant data, string or list,
             lane_type: lane type, [e.g. i8x16, i16x8, i32x4, f32x4]
         """
 
         if lane_type.lower().find('x') == -1:
-            return self.const(val, lane_type)
+            return self.const(value, lane_type)
 
         lane_cnt = int(lane_type[1:].split('x')[1])
 
-        # val is a string type, generating constant data
-        # of val according to the number of lanes
-        if isinstance(val, str):
-            data_elem = [val] * lane_cnt
+        # value is a string type, generating constant data
+        # of value according to the number of lanes
+        if isinstance(value, str):
+            data_elem = [value] * lane_cnt
 
-        # If val is type of list, generate constant data
+        # If value is type of list, generate constant data
         # according to combination of list contents and number of lanes
-        elif isinstance(val, list):
+        elif isinstance(value, list):
 
             # If it is an empty list, generate all constant data with 0x00
-            if len(val) == 0:
+            if len(value) == 0:
                 return self.v128_const('0x00', lane_type)
 
             data_elem = []
 
-            # Calculate the number of times each element in val is copied
-            times = lane_cnt // len(val)
+            # Calculate the number of times each element in value is copied
+            times = lane_cnt // len(value)
 
             # Calculate whether the data needs to be filled according to
-            # the number of elements in the val list and the number of lanes.
-            complement = lane_cnt % len(val)
+            # the number of elements in the value list and the number of lanes.
+            complement = lane_cnt % len(value)
             complement_item = ''
 
-            # If the number of elements in the val list is greater than the number of lanes,
-            # paste data with the number of lanes from the val list.
+            # If the number of elements in the value list is greater than the number of lanes,
+            # paste data with the number of lanes from the value list.
             if times == 0:
                 times = 1
                 complement = 0
 
-                val = val[0:lane_cnt]
+                value = value[0:lane_cnt]
 
             # Copy data
-            for item in val:
+            for item in value:
                 data_elem.extend([item] * times)
                 complement_item = item
 
@@ -80,4 +80,4 @@ class SIMD(object):
         data_elem = ' '.join(data_elem)
 
         # Returns v128 constant text
-        return self.V128_CONST.format(lane_type, data_elem)
+        return self.V128_CONST.format(lane_type=lane_type, value=data_elem)

--- a/test/core/simd/meta/simd_f64x2_arith.py
+++ b/test/core/simd/meta/simd_f64x2_arith.py
@@ -28,8 +28,8 @@ class Simdf64x2ArithmeticCase(Simdf32x4ArithmeticCase):
     NAN_NUMBERS = ('nan', '-nan', 'nan:0x4000000000000', '-nan:0x4000000000000')
 
     @staticmethod
-    def v128_const(lane, val):
-        return '(v128.const {} {})'.format(lane, ' '.join([str(val)] * 2))
+    def v128_const(lane, value):
+        return '(v128.const {lane_type} {value})'.format(lane_type=lane, value=' '.join([str(value)] * 2))
 
     @property
     def combine_ternary_arith_test_data(self):

--- a/test/core/simd/meta/test_assert.py
+++ b/test/core/simd/meta/test_assert.py
@@ -49,4 +49,4 @@ class AssertReturn:
                 white_space = '\n ' + ' ' * head_len
             results.append(white_space + result)
 
-        return '{}{}){})'.format(assert_return, ''.join(params), ''.join(results))
+        return '{assert_head}{params}){expected_result})'.format(assert_head=assert_return, params=''.join(params), expected_result=''.join(results))


### PR DESCRIPTION
https://github.com/WAVM/WAVM/pull/223

    [simd] Improve simd test generation tool

    - Use names in the string interpolation so its clear
      what each part is supposed to be.
    - Use unified naming converson for params.