### PR TITLE
Truncate extra bits of too-large parameters to splat; closes #149

### DIFF
--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -231,7 +231,7 @@ Construct a vector with `x` replicated to all lanes:
 def S.splat(x):
     result = S.New()
     for i in range(S.Lanes):
-        result[i] = x
+        result[i] = S.Reduce(x)
     return result
 ```
 


### PR DESCRIPTION
Previously it was not clear what to do when passing an `i32` to, e.g., an `i8x16.splat`: the `i32` has more bits than fit in an `i8` lane. As discussed in #149, this change removes the extra bits (potentially losing information) so that the input parameter will fit in the splatted lanes. If at some point the spec adds support for `i8` and `i16` types, then this change would be unnecessary since the splat signature could be, e.g., `i8x16.splat(x: i8)` and no truncation would be required.