### PR TITLE
Update README to specify requiring OCaml 4.08

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -15,7 +15,7 @@ The text format defines modules in S-expression syntax. Moreover, it is generali
 
 ## Building
 
-You'll need OCaml 4.02 or higher. An easy way to get this on Linux is to download the [source tarball from our mirror of the ocaml website](https://wasm.storage.googleapis.com/ocaml-4.02.2.tar.gz) and do the configure / make dance.  On macOS, with [Homebrew](http://brew.sh/) installed, simply `brew install ocaml ocamlbuild`.
+You'll need OCaml 4.08 or higher. An easy way to get this on Linux is to download the [source tarball from our mirror of the ocaml website](https://wasm.storage.googleapis.com/ocaml-4.02.2.tar.gz) and do the configure / make dance.  On macOS, with [Homebrew](http://brew.sh/) installed, simply `brew install ocaml ocamlbuild`.
 
 Once you have OCaml, simply do
 


### PR DESCRIPTION
We now require OCaml 4.08, due to using set_* functions in Bytes module (https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bytes.html) since https://github.com/WebAssembly/simd/pull/144