### PR TITLE
Fix setting bytes when converting from string to V128

### DIFF
--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -17,14 +17,14 @@ include Simd.Make
       | Simd.I8x16 ->
         List.iteri (fun i s -> set_uint8 b i (i8_of_string s)) ss
       | Simd.I16x8 ->
-        List.iteri (fun i s -> set_uint16_le b i (i16_of_string s)) ss
+        List.iteri (fun i s -> set_uint16_le b (i * 2) (i16_of_string s)) ss
       | Simd.I32x4 ->
-        List.iteri (fun i s -> set_int32_le b i (I32.of_string s)) ss
+        List.iteri (fun i s -> set_int32_le b (i * 4) (I32.of_string s)) ss
       | Simd.I64x2 ->
-        List.iteri (fun i s -> set_int64_le b i (I64.of_string s)) ss
+        List.iteri (fun i s -> set_int64_le b (i * 8) (I64.of_string s)) ss
       | Simd.F32x4 ->
-        List.iteri (fun i s -> set_int32_le b i (F32.to_bits (F32.of_string s))) ss
+        List.iteri (fun i s -> set_int32_le b (i * 4) (F32.to_bits (F32.of_string s))) ss
       | Simd.F64x2 ->
-        List.iteri (fun i s -> set_int64_le b i (F64.to_bits (F64.of_string s))) ss);
+        List.iteri (fun i s -> set_int64_le b (i * 8) (F64.to_bits (F64.of_string s))) ss);
       b
   end)


### PR DESCRIPTION
The bytes weren't set correct, because we were not scaling the index
properly.