### PR TITLE
Add some f32x4 instructions

### DIFF
--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -380,6 +380,9 @@ let encode m =
       | Convert (F64 F64Op.ReinterpretInt) -> op 0xbf
       | Convert (V128 _) -> failwith "TODO v128"
 
+      | ExtractLane (V128Op.I32x4ExtractLane imm) -> failwith "TODO v128"
+      | ExtractLane (V128Op.F32x4ExtractLane imm) -> failwith "TODO v128"
+
     let const c =
       list instr c.it; end_ ()
 

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -249,6 +249,10 @@ let rec step (c : config) : config =
         (try Eval_numeric.eval_cvtop cvtop v :: vs', []
         with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])
 
+      | ExtractLane extractop, v :: vs' ->
+        (try Eval_numeric.eval_extractop extractop v :: vs', []
+        with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])
+
       | _ ->
         let s1 = string_of_values (List.rev vs) in
         let s2 = string_of_value_types (List.map type_of (List.rev vs)) in

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -118,26 +118,30 @@ module F64Op = FloatOp (F64) (Values.F64Value)
 
 (* Simd operators *)
 
-module SimdOp (VXX : Simd.S) (Value : ValueType with type t = VXX.t) =
+module SimdOp (SXX : Simd.S) (Value : ValueType with type t = SXX.t) =
 struct
-  (* TODO
   open Ast.SimdOp
 
   let to_value = Value.to_value
   let of_value = of_arg Value.of_value
-  *)
+
+  let unop op =
+    fun v -> match op with
+      | F32x4Abs -> to_value (SXX.f32x4_abs (of_value 1 v))
+      | F32x4ExtractLane imm -> (F32Op.to_value (SXX.f32x4_extract_lane imm (of_value 1 v)))
+      | I32x4ExtractLane imm -> (I32Op.to_value (SXX.i32x4_extract_lane imm (of_value 1 v)))
+
+  let binop op =
+    let f = match op with
+      | F32x4Min -> SXX.f32x4_min
+      | F32x4Max -> SXX.f32x4_max
+    in fun v1 v2 -> to_value (f (of_value 1 v1) (of_value 2 v2))
 
   (* FIXME *)
-  let unop op = failwith "TODO v128"
+  let testop op = failwith "TODO v128 unimplemented testop"
 
   (* FIXME *)
-  let binop op = failwith "TODO v128"
-
-  (* FIXME *)
-  let testop op = failwith "TODO v128"
-
-  (* FIXME *)
-  let relop op = failwith "TODO v128"
+  let relop op = failwith "TODO v128 unimplemented relop"
 end
 
 module V128Op = SimdOp (V128) (Values.V128Value)

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -128,8 +128,6 @@ struct
   let unop op =
     fun v -> match op with
       | F32x4Abs -> to_value (SXX.f32x4_abs (of_value 1 v))
-      | F32x4ExtractLane imm -> (F32Op.to_value (SXX.f32x4_extract_lane imm (of_value 1 v)))
-      | I32x4ExtractLane imm -> (I32Op.to_value (SXX.i32x4_extract_lane imm (of_value 1 v)))
 
   let binop op =
     let f = match op with
@@ -142,6 +140,13 @@ struct
 
   (* FIXME *)
   let relop op = failwith "TODO v128 unimplemented relop"
+
+  let extractop op v =
+    match op with
+    | F32x4ExtractLane imm ->
+      (F32Op.to_value (SXX.f32x4_extract_lane imm (of_value 1 v)))
+    | I32x4ExtractLane imm ->
+      (I32Op.to_value (SXX.i32x4_extract_lane imm (of_value 1 v)))
 end
 
 module V128Op = SimdOp (V128) (Values.V128Value)
@@ -220,6 +225,7 @@ struct
   let cvtop op v = failwith "TODO v128"
 end
 
+let eval_extractop extractop v = V128Op.extractop extractop v
 
 (* Dispatch *)
 

--- a/interpreter/exec/eval_numeric.mli
+++ b/interpreter/exec/eval_numeric.mli
@@ -7,3 +7,4 @@ val eval_binop : Ast.binop -> value -> value -> value
 val eval_testop : Ast.testop -> value -> bool
 val eval_relop : Ast.relop -> value -> value -> bool
 val eval_cvtop : Ast.cvtop -> value -> value
+val eval_extractop : Ast.extractop -> value -> value

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -11,6 +11,8 @@ let lanes shape =
   | F32x4 -> 4
   | F64x2 -> 2
 
+let f32x4_indices = [0; 4; 8; 12]
+
 module type RepType =
 sig
   type t
@@ -20,6 +22,13 @@ sig
   val to_string : t -> string
   val bytewidth : int
   val of_strings : shape -> string list -> t
+  val of_bits : string -> t
+  val to_bits : t -> string
+
+  val to_i32x4 : t -> I32.t list
+
+  val to_f32x4 : t -> F32.t list
+  val of_f32x4 : F32.t list -> t
 end
 
 module type S =
@@ -31,6 +40,13 @@ sig
   val of_bits : bits -> t
   val to_bits : t -> bits
   val of_strings : shape -> string list -> t
+
+  val i32x4_extract_lane : int -> t -> I32.t
+
+  val f32x4_min : t -> t -> t
+  val f32x4_max : t -> t -> t
+  val f32x4_abs : t -> t
+  val f32x4_extract_lane : int -> t -> F32.t
 end
 
 module Make (Rep : RepType) : S with type bits = Rep.t =
@@ -43,4 +59,20 @@ struct
   let of_bits x = x
   let to_bits x = x
   let of_strings = Rep.of_strings
+
+  let to_i32x4 = Rep.to_i32x4
+
+  let i32x4_extract_lane i x = List.nth (to_i32x4 x) i
+
+  let to_f32x4 = Rep.to_f32x4
+  let of_f32x4 = Rep.of_f32x4
+  let f32x4_unop f x =
+    of_f32x4 (List.map f (to_f32x4 x))
+  let f32x4_binop f x y =
+    of_f32x4 (List.map2 f (to_f32x4 x) (to_f32x4 y))
+
+  let f32x4_extract_lane i x = List.nth (to_f32x4 x) i
+  let f32x4_min = f32x4_binop F32.min
+  let f32x4_max = f32x4_binop F32.max
+  let f32x4_abs x = f32x4_unop F32.abs x
 end

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -22,8 +22,6 @@ sig
   val to_string : t -> string
   val bytewidth : int
   val of_strings : shape -> string list -> t
-  val of_bits : string -> t
-  val to_bits : t -> string
 
   val to_i32x4 : t -> I32.t list
 

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -4,6 +4,17 @@ include Simd.Make
     let bytewidth = 16
     let to_string s = s
 
+    let to_i32x4 s =
+      List.map (fun i -> I32.of_bits @@ get_int32_le s i) Simd.f32x4_indices
+
+    let to_f32x4 s =
+      List.map (fun i -> F32.of_bits @@ get_int32_le s i) Simd.f32x4_indices
+
+    let of_f32x4 fs =
+      let b = create bytewidth in
+      List.iter2 (fun i f -> set_int32_le b i (F32.to_bits f)) Simd.f32x4_indices fs;
+      b
+
     let of_strings shape ss =
       if List.length ss <> Simd.lanes shape then raise (Invalid_argument "wrong length");
       let range_check i32 min max at =

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -5,15 +5,15 @@ include Simd.Make
     let to_string s = s
 
     let to_i32x4 s =
-      List.map (fun i -> I32.of_bits @@ get_int32_le s i) Simd.f32x4_indices
+      List.map (fun i -> I32.of_bits @@ Bytes.get_int32_le (Bytes.of_string s) i) Simd.f32x4_indices
 
     let to_f32x4 s =
-      List.map (fun i -> F32.of_bits @@ get_int32_le s i) Simd.f32x4_indices
+      List.map (fun i -> F32.of_bits @@ Bytes.get_int32_le (Bytes.of_string s) i) Simd.f32x4_indices
 
     let of_f32x4 fs =
       let b = create bytewidth in
-      List.iter2 (fun i f -> set_int32_le b i (F32.to_bits f)) Simd.f32x4_indices fs;
-      b
+      List.iter2 (fun i f -> Bytes.set_int32_le b i (F32.to_bits f)) Simd.f32x4_indices fs;
+      Bytes.to_string b
 
     let of_strings shape ss =
       if List.length ss <> Simd.lanes shape then raise (Invalid_argument "wrong length");

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -5,10 +5,10 @@ include Simd.Make
     let to_string s = s
 
     let to_i32x4 s =
-      List.map (fun i -> I32.of_bits @@ Bytes.get_int32_le (Bytes.of_string s) i) Simd.f32x4_indices
+      List.map (fun i -> I32.of_bits (Bytes.get_int32_le (Bytes.of_string s) i)) Simd.f32x4_indices
 
     let to_f32x4 s =
-      List.map (fun i -> F32.of_bits @@ Bytes.get_int32_le (Bytes.of_string s) i) Simd.f32x4_indices
+      List.map (fun i -> F32.of_bits (Bytes.get_int32_le (Bytes.of_string s) i)) Simd.f32x4_indices
 
     let of_f32x4 fs =
       let b = create bytewidth in

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -45,26 +45,28 @@ struct
 end
 
 (* FIXME *)
-module VectorOp =
+module SimdOp =
 struct
-  type unop = TodoUnOp
-  type binop = TodoBinOp
+  type unop = I32x4ExtractLane of int | F32x4ExtractLane of int | F32x4Abs
+  type binop = F32x4Min | F32x4Max
   type testop = TodoTestOp
   type relop = TodoRelOp
   type cvtop = TodoCvtOp
+  type extractop = TodoExtractOp
 end
 
 module I32Op = IntOp
 module I64Op = IntOp
 module F32Op = FloatOp
 module F64Op = FloatOp
-module V128Op = VectorOp
+module V128Op = SimdOp
 
 type unop = (I32Op.unop, I64Op.unop, F32Op.unop, F64Op.unop, V128Op.unop) Values.op
 type binop = (I32Op.binop, I64Op.binop, F32Op.binop, F64Op.binop, V128Op.binop) Values.op
 type testop = (I32Op.testop, I64Op.testop, F32Op.testop, F64Op.testop, V128Op.testop) Values.op
 type relop = (I32Op.relop, I64Op.relop, F32Op.relop, F64Op.relop, V128Op.relop) Values.op
 type cvtop = (I32Op.cvtop, I64Op.cvtop, F32Op.cvtop, F64Op.cvtop, V128Op.cvtop) Values.op
+type extractop = V128Op.extractop
 
 type 'a memop =
   {ty : value_type; align : int; offset : Memory.offset; sz : 'a option}

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -47,12 +47,12 @@ end
 (* FIXME *)
 module SimdOp =
 struct
-  type unop = I32x4ExtractLane of int | F32x4ExtractLane of int | F32x4Abs
+  type unop = F32x4Abs
   type binop = F32x4Min | F32x4Max
   type testop = TodoTestOp
   type relop = TodoRelOp
   type cvtop = TodoCvtOp
-  type extractop = TodoExtractOp
+  type extractop = I32x4ExtractLane of int | F32x4ExtractLane of int
 end
 
 module I32Op = IntOp
@@ -110,6 +110,7 @@ and instr' =
   | Unary of unop                     (* unary numeric operator *)
   | Binary of binop                   (* binary numeric operator *)
   | Convert of cvtop                  (* conversion *)
+  | ExtractLane of extractop              (* extract lane from v128 value *)
 
 
 (* Globals & Functions *)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -203,3 +203,10 @@ let f64_reinterpret_i64 = Convert (F64 F64Op.ReinterpretInt)
 let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
+(* SIMD *)
+let i32x4_extract_lane imm = Unary (V128 (V128Op.I32x4ExtractLane imm))
+
+let f32x4_extract_lane imm = Unary (V128 (V128Op.F32x4ExtractLane imm))
+let f32x4_min = Binary (V128 V128Op.F32x4Min)
+let f32x4_max = Binary (V128 V128Op.F32x4Max)
+let f32x4_abs = Unary (V128 V128Op.F32x4Abs)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -204,9 +204,9 @@ let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
 (* SIMD *)
-let i32x4_extract_lane imm = Unary (V128 (V128Op.I32x4ExtractLane imm))
+let i32x4_extract_lane imm = ExtractLane (V128Op.I32x4ExtractLane imm)
 
-let f32x4_extract_lane imm = Unary (V128 (V128Op.F32x4ExtractLane imm))
+let f32x4_extract_lane imm = ExtractLane (V128Op.F32x4ExtractLane imm)
 let f32x4_min = Binary (V128 V128Op.F32x4Min)
 let f32x4_max = Binary (V128 V128Op.F32x4Max)
 let f32x4_abs = Unary (V128 V128Op.F32x4Abs)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -272,6 +272,7 @@ let rec instr e =
     | Unary op -> unop op, []
     | Binary op -> binop op, []
     | Convert op -> cvtop op, []
+    | ExtractLane op -> failwith "TODO v128"
   in Node (head, inner)
 
 let const c =

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -381,11 +381,14 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".min"
-    { BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min unreachable) }
+    { if s != "f32x4" || s != "f64x2" then error lexbuf "unknown operator";
+      BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min unreachable) }
   | (simd_shape as s)".max"
-    { BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_max unreachable) }
+    { if s != "f32x4" || s != "f64x2" then error lexbuf "unknown operator";
+      BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_max unreachable) }
   | (simd_shape as s)".abs"
-    { UNARY (simdop s unreachable unreachable unreachable unreachable f32x4_abs unreachable) }
+    { if s = "i64x2" then error lexbuf "unknown operator";
+      UNARY (simdop s unreachable unreachable unreachable unreachable f32x4_abs unreachable) }
   | (simd_shape as s) { SIMD_SHAPE (simd_shape s) }
 
   | name as s { VAR s }

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -73,6 +73,18 @@ let numop t i32 i64 f32 f64 =
   | "f64" -> f64
   | _ -> assert false
 
+let unimplemented_simd = fun _ -> failwith "unimplemented simd"
+
+let simdop s i8x16 i16x8 i32x4 i64x2 f32x4 f64x2 =
+  match s with
+  | "i8x16" -> i8x16
+  | "i16x8" -> i16x8
+  | "i32x4" -> i32x4
+  | "i64x2" -> i64x2
+  | "f32x4" -> f32x4
+  | "f64x2" -> f64x2
+  | _ -> assert false
+
 let memsz sz m8 m16 m32 =
   match sz with
   | "8" -> m8
@@ -212,6 +224,10 @@ rule token = parse
   | "global.get" { GLOBAL_GET }
   | "global.set" { GLOBAL_SET }
 
+  | (simd_shape as s)".extract_lane"
+    { EXTRACT_LANE (fun imm ->
+        simdop s unimplemented_simd unimplemented_simd i32x4_extract_lane
+                 unimplemented_simd f32x4_extract_lane unimplemented_simd imm) }
   | (nxx as t)".load"
     { LOAD (fun a o ->
         numop t (i32_load (opt a 2)) (i64_load (opt a 3))
@@ -364,6 +380,12 @@ rule token = parse
   | "input" { INPUT }
   | "output" { OUTPUT }
 
+  | (simd_shape as s)".min"
+    { BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min unreachable) }
+  | (simd_shape as s)".max"
+    { BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_max unreachable) }
+  | (simd_shape as s)".abs"
+    { UNARY (simdop s unreachable unreachable unreachable unreachable f32x4_abs unreachable) }
   | (simd_shape as s) { SIMD_SHAPE (simd_shape s) }
 
   | name as s { VAR s }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -167,6 +167,7 @@ let inline_type_explicit (c : context) x ft at =
 %token CALL CALL_INDIRECT RETURN
 %token LOCAL_GET LOCAL_SET LOCAL_TEE GLOBAL_GET GLOBAL_SET
 %token LOAD STORE OFFSET_EQ_NAT ALIGN_EQ_NAT
+%token EXTRACT_LANE
 %token CONST V128_CONST UNARY BINARY TEST COMPARE CONVERT
 %token UNREACHABLE MEMORY_SIZE MEMORY_GROW
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
@@ -192,6 +193,7 @@ let inline_type_explicit (c : context) x ft at =
 %token<Ast.instr'> COMPARE
 %token<Ast.instr'> CONVERT
 %token<int option -> Memory.offset -> Ast.instr'> LOAD
+%token<int -> Ast.instr'> EXTRACT_LANE
 %token<int option -> Memory.offset -> Ast.instr'> STORE
 %token<string> OFFSET_EQ_NAT
 %token<string> ALIGN_EQ_NAT
@@ -351,6 +353,7 @@ plain_instr :
   | UNARY { fun c -> $1 }
   | BINARY { fun c -> $1 }
   | CONVERT { fun c -> $1 }
+  | EXTRACT_LANE NAT { let at = at () in fun c -> $1 (nat $2 at) }
 
 
 call_instr :

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -95,15 +95,7 @@ let peek i (ell, ts) =
 (* Type Synthesis *)
 
 let type_value = Values.type_of
-let type_unop at = function
-    | Values.V128 unop ->
-      let open V128Op in
-      (match unop with
-      | I32x4ExtractLane _ -> V128Type, I32Type
-      | F32x4ExtractLane _ -> V128Type, F32Type
-      | _ -> V128Type, V128Type
-      )
-    | v -> let t = Values.type_of v in (t, t)
+let type_unop = Values.type_of
 let type_binop = Values.type_of
 let type_testop = Values.type_of
 let type_relop = Values.type_of
@@ -286,8 +278,8 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     [t; t] --> [I32Type]
 
   | Unary unop ->
-    let t1, t2 = type_unop e.at unop in
-    [t1] --> [t2]
+    let t = type_unop unop in
+    [t] --> [t]
 
   | Binary binop ->
     let t = type_binop binop in
@@ -296,6 +288,11 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
   | Convert cvtop ->
     let t1, t2 = type_cvtop e.at cvtop in
     [t1] --> [t2]
+
+  | ExtractLane (V128Op.I32x4ExtractLane _) ->
+    [V128Type] --> [I32Type]
+  | ExtractLane (V128Op.F32x4ExtractLane _) ->
+    [V128Type] --> [F32Type]
 
 and check_seq (c : context) (es : instr list) : infer_stack_type =
   match es with

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -95,7 +95,15 @@ let peek i (ell, ts) =
 (* Type Synthesis *)
 
 let type_value = Values.type_of
-let type_unop = Values.type_of
+let type_unop at = function
+    | Values.V128 unop ->
+      let open V128Op in
+      (match unop with
+      | I32x4ExtractLane _ -> V128Type, I32Type
+      | F32x4ExtractLane _ -> V128Type, F32Type
+      | _ -> V128Type, V128Type
+      )
+    | v -> let t = Values.type_of v in (t, t)
 let type_binop = Values.type_of
 let type_testop = Values.type_of
 let type_relop = Values.type_of
@@ -278,8 +286,8 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     [t; t] --> [I32Type]
 
   | Unary unop ->
-    let t = type_unop unop in
-    [t] --> [t]
+    let t1, t2 = type_unop e.at unop in
+    [t1] --> [t2]
 
   | Binary binop ->
     let t = type_binop binop in


### PR DESCRIPTION
Add f32x4 min, max, abs extract lane, and i32x4 extract lane as examples
of how SIMD operations can be implemented.

extract_lane operations are missing validation, which can be added in
future patches.

With this patch, we don't fully support running the test `simd_f32x4.wast` yet, due to missing parsing of the `result` token in scripts. In particular, right now we only support const literal or a single canonical/arithmetic NaN. We will need to add support for parsing v128.const containing literals and/or canonical/arithmetic NaN, this can be done in a future patch.