### PR TITLE
Remove i64x2 <-> f64x2 conversion opcodes

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -170,12 +170,8 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `f64x2.max`                |    `0xaa`| -                  |
 | `i32x4.trunc_sat_f32x4_s`  |    `0xab`| -                  |
 | `i32x4.trunc_sat_f32x4_u`  |    `0xac`| -                  |
-| `i64x2.trunc_sat_f64x2_s`  |    `0xad`| -                  |
-| `i64x2.trunc_sat_f64x2_u`  |    `0xae`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xaf`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xb0`| -                  |
-| `f64x2.convert_i64x2_s`    |    `0xb1`| -                  |
-| `f64x2.convert_i64x2_u`    |    `0xb2`| -                  |
 | `v8x16.swizzle`            |    `0xc0`| -                  |
 | `v8x16.shuffle`            |    `0xc1`| s:LaneIdx32[16]    |
 | `v8x16.load_splat`         |    `0xc2`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -150,12 +150,8 @@
 | `f64x2.max`                | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.trunc_sat_f32x4_s`  |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.trunc_sat_f64x2_s`  | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.trunc_sat_f64x2_u`  | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `f64x2.convert_i64x2_s`    | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
-| `f64x2.convert_i64x2_u`    | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `v8x16.swizzle`            | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
 | `v8x16.shuffle`            |            `-msimd128`[5] | :white_check_mark:[5] | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.load8x8_s`          | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -859,8 +859,6 @@ Lane-wise IEEE `squareRoot`.
 ### Integer to floating point
 * `f32x4.convert_i32x4_s(a: v128) -> v128`
 * `f32x4.convert_i32x4_u(a: v128) -> v128`
-* `f64x2.convert_i64x2_s(a: v128) -> v128`
-* `f64x2.convert_i64x2_u(a: v128) -> v128`
 
 Lane-wise conversion from integer to floating point. Some integer values will be
 rounded.
@@ -868,8 +866,6 @@ rounded.
 ### Floating point to integer with saturation
 * `i32x4.trunc_sat_f32x4_s(a: v128) -> v128`
 * `i32x4.trunc_sat_f32x4_u(a: v128) -> v128`
-* `i64x2.trunc_sat_f64x2_s(a: v128) -> v128`
-* `i64x2.trunc_sat_f64x2_u(a: v128) -> v128`
 
 Lane-wise saturating conversion from floating point to integer using the IEEE
 `convertToIntegerTowardZero` function. If any input lane is a NaN, the


### PR DESCRIPTION
In the SIMD sync on 2020-01-14, we discussed the challenges with
implementing these instructions in a performant way on 32-bit archs. And
even on 64-bit arch, like x64, it requires AVX-512 for good codegen.
There is consensus that because it is uncommon for such instructions to
be used, and that hardware support is not widespread, we can remove
these.