### PR TITLE
Adjust two more tests from recent changes

### DIFF
--- a/test/core/simd/simd_lane.wast
+++ b/test/core/simd/simd_lane.wast
@@ -917,10 +917,10 @@
   "type mismatch"
 )
 (assert_invalid
-  (module quote
-    "(func $i8x16.extract_lane_s-2nd-arg-empty (result i32)"
-    "  (i8x16.extract_lane_s 0)"
-    ")"
+  (module
+    (func $i8x16.extract_lane_s-2nd-arg-empty (result i32)
+      (i8x16.extract_lane_s 0)
+    )
   )
   "type mismatch"
 )
@@ -941,10 +941,10 @@
   "type mismatch"
 )
 (assert_invalid
-  (module quote
-    "(func $i16x8.extract_lane_u-2nd-arg-empty (result i32)"
-    "  (i16x8.extract_lane_u 0)"
-    ")"
+  (module
+    (func $i16x8.extract_lane_u-2nd-arg-empty (result i32)
+      (i16x8.extract_lane_u 0)
+    )
   )
   "type mismatch"
 )


### PR DESCRIPTION
The `assert_invalid` directive isn't intended to be used with `(module
quote ...)` and the `module quote` part can be removed here as well
since the module should successfully parse, but fail to validate.