### PR TITLE
Add .bitmask instruction family

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -114,6 +114,7 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i8x16.neg`                |    `0x61`| -                  |
 | `i8x16.any_true`           |    `0x62`| -                  |
 | `i8x16.all_true`           |    `0x63`| -                  |
+| `i8x16.bitmask`            |    `0x64`| -                  |
 | `i8x16.narrow_i16x8_s`     |    `0x65`| -                  |
 | `i8x16.narrow_i16x8_u`     |    `0x66`| -                  |
 | `i8x16.shl`                |    `0x6b`| -                  |
@@ -134,6 +135,7 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i16x8.neg`                |    `0x81`| -                  |
 | `i16x8.any_true`           |    `0x82`| -                  |
 | `i16x8.all_true`           |    `0x83`| -                  |
+| `i16x8.bitmask`            |    `0x84`| -                  |
 | `i16x8.narrow_i32x4_s`     |    `0x85`| -                  |
 | `i16x8.narrow_i32x4_u`     |    `0x86`| -                  |
 | `i16x8.widen_low_i8x16_s`  |    `0x87`| -                  |
@@ -159,6 +161,7 @@ The `v8x16.shuffle` instruction has 16 bytes after `simdop`.
 | `i32x4.neg`                |    `0xa1`| -                  |
 | `i32x4.any_true`           |    `0xa2`| -                  |
 | `i32x4.all_true`           |    `0xa3`| -                  |
+| `i32x4.bitmask`            |    `0xa4`| -                  |
 | `i32x4.widen_low_i16x8_s`  |    `0xa7`| -                  |
 | `i32x4.widen_high_i16x8_s` |    `0xa8`| -                  |
 | `i32x4.widen_low_i16x8_u`  |    `0xa9`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -87,6 +87,7 @@
 | `i8x16.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i8x16.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
 | `i8x16.narrow_i16x8_s`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.narrow_i16x8_u`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.shl`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -107,6 +108,7 @@
 | `i16x8.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i16x8.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
 | `i16x8.narrow_i32x4_s`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.narrow_i32x4_u`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.widen_low_i8x16_s`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -132,6 +134,7 @@
 | `i32x4.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i32x4.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
 | `i32x4.widen_low_i16x8_s`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.widen_high_i16x8_s` |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.widen_low_i16x8_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -82,7 +82,7 @@
 | i8x16.neg            | 0x61   | i16x8.neg                | 0x81   | i32x4.neg                | 0xa1   | i64x2.neg   | 0xc1   |
 | i8x16.any_true       | 0x62   | i16x8.any_true           | 0x82   | i32x4.any_true           | 0xa2   | ----        | 0xc2   |
 | i8x16.all_true       | 0x63   | i16x8.all_true           | 0x83   | i32x4.all_true           | 0xa3   | ----        | 0xc3   |
-| ---- bitmask ----    | 0x64   | ---- bitmask ----        | 0x84   | ---- bitmask ----        | 0xa4   | ----        | 0xc4   |
+| i8x16.bitmask        | 0x64   | i16x8.bitmask            | 0x84   | i32x4.bitmask            | 0xa4   | ----        | 0xc4   |
 | i8x16.narrow_i16x8_s | 0x65   | i16x8.narrow_i32x4_s     | 0x85   | ---- narrow ----         | 0xa5   | ----        | 0xc5   |
 | i8x16.narrow_i16x8_u | 0x66   | i16x8.narrow_i32x4_u     | 0x86   | ---- narrow ----         | 0xa6   | ----        | 0xc6   |
 | ---- widen ----      | 0x67   | i16x8.widen_low_i8x16_s  | 0x87   | i32x4.widen_low_i16x8_s  | 0xa7   | ----        | 0xc7   |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -648,6 +648,24 @@ def S.all_true(a):
     return 1
 ```
 
+## Bitmask extraction
+
+* `i8x16.bitmask(a: v128) -> i32`
+* `i16x8.bitmask(a: v128) -> i32`
+* `i32x4.bitmask(a: v128) -> i32`
+
+These operations extract the high bit for each lane in `a` and produce a scalar
+mask with all bits concatenated.
+
+```python
+def S.bitmask(a):
+    result = 0
+    for i in range(S.Lanes):
+        if a[i] < 0:
+            result = result | (1 << i)
+    return result
+```
+
 ## Comparisons
 
 The comparison operations all compare two vectors lane-wise, and produce a mask


### PR DESCRIPTION
# Introduction

A class of SIMD operations requires to perform processing in vector registers first, and then post-process some of the lanes using scalar code. Often this involves doing a vectorized comparison, followed by inspection of the lanes of the comparison mask.

This can be done using lane extraction, but it's usually slow - for example, in a vectorized memchr implementation, if any of the lanes compare as equal to the pattern, we need to quickly find the right lane.

This proposal suggests adding three new instruction that can faciliate this operation - they take all high bits from the lanes of the input vector and concatenate it into the scalar mask. The resulting mask can then be used with ctz instructions to find the first matching element, or as a table lookup index / for other needs.

See #131 and #169 for other examples of workloads where this can be beneficial.

These instructions are impossible to synthesize or emulate given the current set of WASM SIMD instructions short of extracting individual lane and performing the bit extraction.

# Lowering for x64 (SSE2)

i8x16.bitmask maps directly to pmovmskb (SSE2)

i16x8.bitmask maps to a two-instruction sequence, assuming we have a zeroed vector register: packsswb converts from 16-bit integers to 8-bit integers with saturation, pmovmskb computes the mask. (or 3 instructions if we need to zero a register, or use packsswb on the same vector and then mask off the low 8 bits of the result)

i32x4.bitmask maps directly to movmskps (SSE1)

# Lowering for PowerPC

PowerPC supports a more general form of this, vbpermq/vbpermd, that allow selecting *arbitrary* bits from the input vector:

https://www.ibm.com/support/knowledgecenter/SSGH3R_16.1.0/com.ibm.xlcpp161.aix.doc/compiler_ref/vec_bperm_p8.html

Using a predefined mask with indices of the bits (which can be loaded from memory or synthesized using lvlsl and a vector shift), the lowering is equivalent to x64 from that point on - i8x16.bitmask lowers to lvsl+shift+vbpermq, etc.

# Lowering for ARM64

While ARM doesn't directly support this instruction, it supports horizontal add (which is not exposed in WASM), which makes it possible to emulate these as follows:

```
int bitmask_8(int8x16_t val) {
    static const uint8x16_t mask = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};

    uint8x16_t masked = vandq_u8(mask, (uint8x16_t)vshrq_n_s8(val, 7));
    uint8x16_t maskedhi = vextq_u8(masked, masked, 8);

    return vaddvq_u16((uint16x8_t)vzip1q_u8(masked, maskedhi));
}

int bitmask_16(int16x8_t val) {
    static const uint16x8_t mask = { 1, 2, 4, 8, 16, 32, 64, 128 };
    return vaddvq_u16(vandq_u16((uint16x8_t)vshrq_n_s16(val, 15), mask));
}

int bitmask_32(int32x4_t val) {
    static const uint32x4_t mask = { 1, 2, 4, 8 };
    return vaddvq_u32(vandq_u32((uint32x4_t)vshrq_n_s32(val, 31), mask));
} 
```

i8x16.bitmask lowering is the most expensive, 6 vector instructions and 2 scalar instructions; other bitmask instructions lower to 4 vector instructions + 2 scalar instructions (including 1 vector load).

32-bit ARM doesn't have vaddvq but it can be emulated using paired adds (vpadd)

# Performance cliffs

The highest disparity in this proposal is between i8x16.bitmask for ARM64 (6 vector + 2 scalar instructions) and x64 (1 instruction). However, this type of disparity is relatively common for other instructions in this proposal, and, *crucially*, if the algorithm in question requires i8x16.bitmask, the lowering by the WASM backend is going to be substantially better than any lowering possible in WASM SIMD by using other instructions to emulate this.

Closes #131 
Closes #169
