### PR TITLE
[test] Fixed mismatched op names in comments

### DIFF
--- a/test/core/simd/meta/simd_f32x4.py
+++ b/test/core/simd/meta/simd_f32x4.py
@@ -192,6 +192,7 @@ class Simdf32x4Case(Simdf32x4ArithmeticCase):
         # Add test for operations with constant operands
         for key in lst_oprt_with_const_assert:
 
+            op_name = self.full_op_name(key)
             case_cnt = 0
             for case_data in lst_oprt_with_const_assert[key]:
 

--- a/test/core/simd/meta/simd_f64x2.py
+++ b/test/core/simd/meta/simd_f64x2.py
@@ -209,6 +209,7 @@ class Simdf64x2Case(Simdf32x4Case):
         # Add test for operations with constant operands
         for key in const_test_data:
 
+            op_name = self.full_op_name(key)
             case_cnt = 0
             for case_data in const_test_data[key]:
 

--- a/test/core/simd/simd_f32x4.wast
+++ b/test/core/simd/simd_f32x4.wast
@@ -29,12 +29,12 @@
   (func (export "f32x4.abs_with_const") (result v128) (f32x4.abs (v128.const f32x4 -0 -1 -2 -3)))
 )
 
-;; f32x4.abs const vs const
+;; f32x4.min const vs const
 (assert_return (invoke "f32x4.min_with_const_0") (v128.const f32x4 0 1 1 -3))
 (assert_return (invoke "f32x4.min_with_const_1") (v128.const f32x4 0 1 2 3))
 (assert_return (invoke "f32x4.min_with_const_2") (v128.const f32x4 0x00 0x01 0x01 0x80000000))
 (assert_return (invoke "f32x4.min_with_const_3") (v128.const f32x4 0x00 0x01 0x02 0x80000000))
-;; f32x4.abs param vs const
+;; f32x4.min param vs const
 (assert_return (invoke "f32x4.min_with_const_5" (v128.const f32x4 0 2 1 3))
                                                 (v128.const f32x4 0 1 1 -3))
 (assert_return (invoke "f32x4.min_with_const_6" (v128.const f32x4 0 1 2 3))
@@ -43,12 +43,12 @@
                                                 (v128.const f32x4 0x00 0x01 0x01 0x80000000))
 (assert_return (invoke "f32x4.min_with_const_8" (v128.const f32x4 0x00 0x01 0x02 0x80000000))
                                                 (v128.const f32x4 0x00 0x01 0x02 0x80000000))
-;; f32x4.abs const vs const
+;; f32x4.max const vs const
 (assert_return (invoke "f32x4.max_with_const_10") (v128.const f32x4 0 2 2 3))
 (assert_return (invoke "f32x4.max_with_const_11") (v128.const f32x4 0 1 2 3))
 (assert_return (invoke "f32x4.max_with_const_12") (v128.const f32x4 0x00 0x02 0x02 2147483648))
 (assert_return (invoke "f32x4.max_with_const_13") (v128.const f32x4 0x00 0x01 0x02 0x80000000))
-;; f32x4.abs param vs const
+;; f32x4.max param vs const
 (assert_return (invoke "f32x4.max_with_const_15" (v128.const f32x4 0 2 1 3))
                                                  (v128.const f32x4 0 2 2 3))
 (assert_return (invoke "f32x4.max_with_const_16" (v128.const f32x4 0 1 2 3))

--- a/test/core/simd/simd_f64x2.wast
+++ b/test/core/simd/simd_f64x2.wast
@@ -46,12 +46,12 @@
   (func (export "f64x2.abs_with_const_36") (result v128) (f64x2.abs (v128.const f64x2 -2 -3)))
 )
 
-;; f64x2.abs const vs const
+;; f64x2.min const vs const
 (assert_return (invoke "f64x2.min_with_const_0") (v128.const f64x2 0 1))
 (assert_return (invoke "f64x2.min_with_const_1") (v128.const f64x2 1 -3))
 (assert_return (invoke "f64x2.min_with_const_2") (v128.const f64x2 0 1))
 (assert_return (invoke "f64x2.min_with_const_3") (v128.const f64x2 2 3))
-;; f64x2.abs param vs const
+;; f64x2.min param vs const
 (assert_return (invoke "f64x2.min_with_const_4") (v128.const f64x2 0x00 0x01))
 (assert_return (invoke "f64x2.min_with_const_5") (v128.const f64x2 0x01 0x80000000))
 (assert_return (invoke "f64x2.min_with_const_6") (v128.const f64x2 0x00 0x01))
@@ -72,12 +72,12 @@
                                                  (v128.const f64x2 0x00 0x01))
 (assert_return (invoke "f64x2.min_with_const_16" (v128.const f64x2 0x02 0x80000000))
                                                  (v128.const f64x2 0x02 0x80000000))
-;; f64x2.abs const vs const
+;; f64x2.max const vs const
 (assert_return (invoke "f64x2.max_with_const_18") (v128.const f64x2 0 2))
 (assert_return (invoke "f64x2.max_with_const_19") (v128.const f64x2 2 3))
 (assert_return (invoke "f64x2.max_with_const_20") (v128.const f64x2 0 1))
 (assert_return (invoke "f64x2.max_with_const_21") (v128.const f64x2 2 3))
-;; f64x2.abs param vs const
+;; f64x2.max param vs const
 (assert_return (invoke "f64x2.max_with_const_22") (v128.const f64x2 0x00 0x02))
 (assert_return (invoke "f64x2.max_with_const_23") (v128.const f64x2 0x02 2147483648))
 (assert_return (invoke "f64x2.max_with_const_24") (v128.const f64x2 0x00 0x01))


### PR DESCRIPTION
Pulled from https://github.com/WAVM/WAVM/pull/269