### PR TITLE
Fix string comparison

### DIFF
--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -381,10 +381,10 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".min"
-    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown min operator";
+    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
       BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min unreachable) }
   | (simd_shape as s)".max"
-    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown max operator";
+    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
       BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_max unreachable) }
   | (simd_shape as s)".abs"
     { if s = "i64x2" then error lexbuf "unknown operator";

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -381,10 +381,10 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".min"
-    { if s != "f32x4" || s != "f64x2" then error lexbuf "unknown operator";
+    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown min operator";
       BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min unreachable) }
   | (simd_shape as s)".max"
-    { if s != "f32x4" || s != "f64x2" then error lexbuf "unknown operator";
+    { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown max operator";
       BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_max unreachable) }
   | (simd_shape as s)".abs"
     { if s = "i64x2" then error lexbuf "unknown operator";


### PR DESCRIPTION
Classic newbie mistake of using != on strings. Plus I got the
conditional wrong - it should error if s is none of the valid simd
shapes.

Also have the error message a bit more verbose.