### PR TITLE
Parse v128.const of nans in result_list of assert_return with a recursive result' type

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -250,6 +250,7 @@ let assert_return ress ts at =
         Compare (eq_of t') @@ at;
         Test (Values.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
+    | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
   in [], List.flatten (List.rev_map test ress)
 
 let wrap module_name item_name wrap_action wrap_assertion at =
@@ -330,10 +331,12 @@ let of_nan = function
 let of_result res =
   match res.it with
   | LitResult lit -> of_literal lit
-  | NanResult nanop ->
+  | NanResult nanop -> begin
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n | Values.F64 n -> of_nan n
+    end
+  | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
 
 let rec of_definition def =
   match def.it with

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -19,6 +19,7 @@ type result = result' Source.phrase
 and result' =
   | LitResult of Ast.literal
   | NanResult of nanop
+  | SimdF32x4Result of result' * result' * result' * result'
 
 type assertion = assertion' Source.phrase
 and assertion' =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -445,6 +445,7 @@ let nan = function
 let result res =
   match res.it with
   | LitResult lit -> literal lit
+  | SimdF32x4Result _ -> failwith "unimplemented"
   | NanResult nanop ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -48,6 +48,20 @@ let simd_literal shape ss at =
     | Failure _ -> error at "constant out of range"
     | Invalid_argument _ -> error at "wrong number of lane literals"
 
+let simd_lane_nan shape l at =
+  let open Simd in
+  match shape with
+  | F32x4 -> NanResult (Values.F32 l @@ at)
+  | F64x2 -> NanResult (Values.F64 l @@ at)
+  | _ -> error at "invalid simd constant"
+
+let simd_lane_lit shape l at =
+  let open Simd in
+  match shape with
+  | F32x4 -> LitResult (Values.F32 (F32.of_string l) @@ at)
+  | F64x2 -> LitResult (Values.F64 (F64.of_string l) @@ at)
+  | _ -> error at "invalid simd constant"
+
 let nanop f nan =
   let open Source in
   let open Values in
@@ -846,7 +860,9 @@ meta :
   | LPAR OUTPUT script_var_opt RPAR { Output ($3, None) @@ at () }
 
 const :
-  | LPAR CONST literal RPAR { snd (literal $2 $3) @@ ati 3 }
+  | LPAR CONST literal RPAR { print_endline "const"; snd (literal $2 $3) @@ ati 3 }
+
+v128const:
   | LPAR V128_CONST SIMD_SHAPE literal_list RPAR {
       snd (simd_literal $3 $4 (at ())) @@ ati 4
   }
@@ -854,10 +870,18 @@ const :
 const_list :
   | /* empty */ { [] }
   | const const_list { $1 :: $2 }
+  | v128const const_list { $1 :: $2 }
+
+numpat :
+  | literal { fun s -> simd_lane_lit s $1.it $1.at }
+  | NAN { fun s -> simd_lane_nan s $1 (ati 3) }
 
 result :
-  | const { LitResult $1 @@ at () }
-  | LPAR CONST NAN RPAR { NanResult (nanop $2 ($3 @@ ati 3)) @@ at () }
+  | LPAR V128_CONST SIMD_SHAPE numpat numpat numpat numpat RPAR {
+      SimdF32x4Result ($4 $3, $5 $3, $6 $3, $7 $3) @@ at ()
+  }
+  | const { (LitResult $1 ) @@ at () }
+  | LPAR CONST NAN RPAR { (NanResult (nanop $2 ($3 @@ ati 3))) @@ at () }
 
 result_list :
   | /* empty */ { [] }


### PR DESCRIPTION
Add a new `result'` case, `SimdF32x4Result`, that contains 4 `result'`, representing values in the lane, which can be a `F32` literal, or a `Nan`. This makes `result'` a recursive type.

I had to move the parsing of v128_const rule out of const, to avoid a shift reduce conflict in the `result :` rule.