### PR TITLE
Parse v128.const of nans in result_list of assert_return by wrapping existing result type

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -222,7 +222,7 @@ let run ts at =
 let assert_return ress ts at =
   let test res =
     match res.it with
-    | LitResult lit ->
+    | ValueResult (LitResult lit) ->
       let t', reinterpret = reinterpret_of (Values.type_of lit.it) in
       [ reinterpret @@ at;
         Const lit @@ at;
@@ -230,7 +230,7 @@ let assert_return ress ts at =
         Compare (eq_of t') @@ at;
         Test (Values.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
-    | NanResult nanop ->
+    | ValueResult (NanResult nanop) ->
       let nan =
         match nanop.it with
         | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
@@ -250,6 +250,7 @@ let assert_return ress ts at =
         Compare (eq_of t') @@ at;
         Test (Values.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
+    | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
   in [], List.flatten (List.rev_map test ress)
 
 let wrap module_name item_name wrap_action wrap_assertion at =
@@ -329,8 +330,9 @@ let of_nan = function
 
 let of_result res =
   match res.it with
-  | LitResult lit -> of_literal lit
-  | NanResult nanop ->
+  | ValueResult (LitResult lit) -> of_literal lit
+  | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
+  | ValueResult (NanResult nanop) ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n | Values.F64 n -> of_nan n

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -222,7 +222,7 @@ let run ts at =
 let assert_return ress ts at =
   let test res =
     match res.it with
-    | ValueResult (LitResult lit) ->
+    | NumResult { it = LitPat lit; _ } ->
       let t', reinterpret = reinterpret_of (Values.type_of lit.it) in
       [ reinterpret @@ at;
         Const lit @@ at;
@@ -230,7 +230,7 @@ let assert_return ress ts at =
         Compare (eq_of t') @@ at;
         Test (Values.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
-    | ValueResult (NanResult nanop) ->
+    | NumResult { it = NanPat nanop; _ } ->
       let nan =
         match nanop.it with
         | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
@@ -250,7 +250,7 @@ let assert_return ress ts at =
         Compare (eq_of t') @@ at;
         Test (Values.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
-    | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
+    | SimdResult _ -> failwith "unimplemented"
   in [], List.flatten (List.rev_map test ress)
 
 let wrap module_name item_name wrap_action wrap_assertion at =
@@ -330,9 +330,9 @@ let of_nan = function
 
 let of_result res =
   match res.it with
-  | ValueResult (LitResult lit) -> of_literal lit
-  | SimdF32x4Result (_, _, _, _) -> failwith "unimplemented"
-  | ValueResult (NanResult nanop) ->
+  | NumResult { it = LitPat lit; _ } -> of_literal lit
+  | SimdResult _ -> failwith "unimplemented"
+  | NumResult { it = NanPat nanop; _ } ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n | Values.F64 n -> of_nan n

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -250,16 +250,23 @@ let string_of_nan = function
 
 let type_of_result r =
   match r with
-  | LitResult v -> Values.type_of v.it
-  | NanResult n -> Values.type_of n.it
+  | ValueResult (LitResult v) -> Values.type_of v.it
+  | ValueResult (NanResult n) -> Values.type_of n.it
+  | SimdF32x4Result (_, _, _, _) -> let open Types in V128Type
 
-let string_of_result r =
+let string_of_result_pat (r : result_pat) =
   match r with
-  | LitResult v -> Values.string_of_value v.it
-  | NanResult nanop ->
+  | (LitResult v) -> Values.string_of_value v.it
+  | (NanResult nanop) ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n | Values.F64 n -> string_of_nan n
+
+let string_of_result r =
+  match r with
+  | ValueResult v -> string_of_result_pat v
+  | SimdF32x4Result (s1, s2, s3, s4) ->
+    String.concat " " (List.map string_of_result_pat [s1; s2; s3; s4])
 
 let string_of_results = function
   | [r] -> string_of_result r
@@ -340,24 +347,43 @@ let run_action act : Values.value list =
     | None -> Assert.error act.at "undefined export"
     )
 
-let assert_result at got expect =
+
+let assert_result_pat at v r =
   let open Values in
+  match r with
+    | LitResult v' -> v <> v'.it
+    | NanResult nanop ->
+      match nanop.it, v with
+      | F32 CanonicalNan, F32 z -> z <> F32.pos_nan && z <> F32.neg_nan
+      | F64 CanonicalNan, F64 z -> z <> F64.pos_nan && z <> F64.neg_nan
+      | F32 ArithmeticNan, F32 z ->
+        let pos_nan = F32.to_bits F32.pos_nan in
+        Int32.logand (F32.to_bits z) pos_nan <> pos_nan
+      | F64 ArithmeticNan, F64 z ->
+        let pos_nan = F64.to_bits F64.pos_nan in
+        Int64.logand (F64.to_bits z) pos_nan <> pos_nan
+      | _, _ -> false
+
+let assert_result at got expect =
   if
     List.length got <> List.length expect ||
     List.exists2 (fun v r ->
       match r with
-      | LitResult v' -> v <> v'.it
-      | NanResult nanop ->
-        match nanop.it, v with
-        | F32 CanonicalNan, F32 z -> z <> F32.pos_nan && z <> F32.neg_nan
-        | F64 CanonicalNan, F64 z -> z <> F64.pos_nan && z <> F64.neg_nan
-        | F32 ArithmeticNan, F32 z ->
-          let pos_nan = F32.to_bits F32.pos_nan in
-          Int32.logand (F32.to_bits z) pos_nan <> pos_nan
-        | F64 ArithmeticNan, F64 z ->
-          let pos_nan = F64.to_bits F64.pos_nan in
-          Int64.logand (F64.to_bits z) pos_nan <> pos_nan
-        | _, _ -> false
+      | ValueResult v' -> assert_result_pat at v v'
+      | SimdF32x4Result (e0, e1, e2, e3) ->
+        begin
+            let open Values in
+            match v with
+            | V128 v ->
+                    let l0 = F32 (V128.f32x4_extract_lane 0 v) in
+                    let l1 = F32 (V128.f32x4_extract_lane 1 v) in
+                    let l2 = F32 (V128.f32x4_extract_lane 2 v) in
+                    let l3 = F32 (V128.f32x4_extract_lane 3 v) in
+                      List.exists2 (fun v r ->
+                          assert_result_pat at v r
+                      ) [l0; l1; l2; l3]  [e0; e1; e2; e3]
+            | _ -> failwith "impossible"
+        end
     ) got expect
   then begin
     print_string "Result: "; print_values got;

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -254,10 +254,10 @@ let type_of_result r =
   | NumResult { it = NanPat v ; _ } -> Values.type_of v.it
   | SimdResult (_, _) -> let open Types in V128Type
 
-let string_of_num_pat (r : num_pat) =
-  match r with
-  | { it = LitPat v; _ } -> Values.string_of_value v.it
-  | { it = NanPat nanop; _ } ->
+let string_of_num_pat (p : num_pat) =
+  match p.it with
+  | LitPat v -> Values.string_of_value v.it
+  | NanPat nanop ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n | Values.F64 n -> string_of_nan n
@@ -348,11 +348,11 @@ let run_action act : Values.value list =
     )
 
 
-let assert_num_pat at v r =
+let assert_num_pat at v p =
   let open Values in
-  match r with
-    | { it = LitPat v'; _ } -> v <> v'.it
-    | { it = NanPat nanop; _ } ->
+  match p.it with
+    | (LitPat v') -> v <> v'.it
+    | (NanPat nanop) ->
       match nanop.it, v with
       | F32 CanonicalNan, F32 z -> z <> F32.pos_nan && z <> F32.neg_nan
       | F64 CanonicalNan, F64 z -> z <> F64.pos_nan && z <> F64.neg_nan

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -17,6 +17,9 @@ and nan = CanonicalNan | ArithmeticNan
 
 type result = result' Source.phrase
 and result' =
+  | ValueResult of result_pat
+  | SimdF32x4Result of result_pat * result_pat * result_pat * result_pat
+and result_pat =
   | LitResult of Ast.literal
   | NanResult of nanop
 

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -15,13 +15,15 @@ type nanop = nanop' Source.phrase
 and nanop' = (unit, unit, nan, nan, unit) Values.op
 and nan = CanonicalNan | ArithmeticNan
 
+type num_pat = num_pat' Source.phrase
+and num_pat' =
+  | LitPat of Ast.literal
+  | NanPat of nanop
+
 type result = result' Source.phrase
 and result' =
-  | ValueResult of result_pat
-  | SimdF32x4Result of result_pat * result_pat * result_pat * result_pat
-and result_pat =
-  | LitResult of Ast.literal
-  | NanResult of nanop
+  | NumResult of num_pat
+  | SimdResult of Simd.shape * num_pat list
 
 type assertion = assertion' Source.phrase
 and assertion' =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -444,9 +444,9 @@ let nan = function
 
 let result res =
   match res.it with
-  | ValueResult (LitResult lit) -> literal lit
-  | SimdF32x4Result _ -> failwith "unimplemented"
-  | ValueResult (NanResult nanop) ->
+  | NumResult { it = LitPat lit; _ } -> literal lit
+  | SimdResult _ -> failwith "unimplemented"
+  | NumResult { it = NanPat nanop; _ } ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n -> Node ("f32.const " ^ nan n, [])

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -444,8 +444,9 @@ let nan = function
 
 let result res =
   match res.it with
-  | LitResult lit -> literal lit
-  | NanResult nanop ->
+  | ValueResult (LitResult lit) -> literal lit
+  | SimdF32x4Result _ -> failwith "unimplemented"
+  | ValueResult (NanResult nanop) ->
     match nanop.it with
     | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
     | Values.F32 n -> Node ("f32.const " ^ nan n, [])

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -442,15 +442,19 @@ let nan = function
   | CanonicalNan -> "nan:canonical"
   | ArithmeticNan -> "nan:arithmetic"
 
+let result_numpat res =
+    match res with
+    | LitPat lit -> literal lit
+    | NanPat nanop ->
+        match nanop.it with
+        | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
+        | Values.F32 n -> Node ("f32.const " ^ nan n, [])
+        | Values.F64 n -> Node ("f64.const " ^ nan n, [])
+
 let result res =
   match res.it with
-  | NumResult { it = LitPat lit; _ } -> literal lit
   | SimdResult _ -> failwith "unimplemented"
-  | NumResult { it = NanPat nanop; _ } ->
-    match nanop.it with
-    | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
-    | Values.F32 n -> Node ("f32.const " ^ nan n, [])
-    | Values.F64 n -> Node ("f64.const " ^ nan n, [])
+  | NumResult n -> result_numpat n.it
 
 let assertion mode ass =
   match ass.it with


### PR DESCRIPTION
Wrap existing `LitResult` and `NanResult` in a `ValueResult`, and create another case `SimdF32x4Result` to represent a f32x4 result. This allows us to parse v128.const containing literals and/or nans without any recursive types.

This is in contrast to #217 which makes `result'` recursive, and so some functions in `run.ml` have to be changed to recursive.

I had to move the parsing of v128_const rule out of const, to avoid a shift reduce conflict in the `result :` rule.