### PR TITLE
Update ImplementationStatus to reflect status quo

### DIFF
--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -4,17 +4,17 @@
 | `v128.store`               |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.const`               | `-munimplemented-simd128` |                       | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.splat`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v8x16.load_splat`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v8x16.load_splat`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i8x16.extract_lane_s`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.extract_lane_u`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.replace_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.splat`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v16x8.load_splat`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v16x8.load_splat`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i16x8.extract_lane_s`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.extract_lane_u`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.replace_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.splat`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v32x4.load_splat`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v32x4.load_splat`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i32x4.extract_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.replace_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.splat`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -24,7 +24,7 @@
 | `f32x4.extract_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.replace_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.splat`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v64x2.load_splat`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v64x2.load_splat`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `f64x2.extract_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f64x2.replace_lane`       |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.eq`                 |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -71,7 +71,7 @@
 | `f64x2.ge`                 |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.not`                 |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.and`                 |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v128.andnot`              | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v128.andnot`              | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `v128.or`                  |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.xor`                 |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `v128.bitselect`           |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -132,7 +132,7 @@
 | `i64x2.shr_u`              |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.add`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.sub`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `i64x2.mul`                |                           |                       | :heavy_check_mark: |                    |
+| `i64x2.mul`                |                           |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `f32x4.abs`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.neg`                |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.sqrt`               |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
@@ -155,14 +155,14 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `v8x16.swizzle`            | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `v8x16.shuffle`            |            `-msimd128`[5] | :white_check_mark:[5] | :heavy_check_mark: | :heavy_check_mark: |
-| `i16x8.load8x8_s`          | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `i16x8.load8x8_u`          | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `i32x4.load16x4_s`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `i32x4.load16x4_u`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `i64x2.load32x2_s`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
-| `i64x2.load32x2_u`         | `-munimplemented-simd128` |                       | :heavy_check_mark: |                    |
+| `v8x16.swizzle`            | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `v8x16.shuffle`            |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `i16x8.load8x8_s`          | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i16x8.load8x8_u`          | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i32x4.load16x4_s`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i32x4.load16x4_u`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i64x2.load32x2_s`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
+| `i64x2.load32x2_u`         | `-munimplemented-simd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i8x16.narrow_i16x8_s`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i8x16.narrow_i16x8_u`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i16x8.narrow_i32x4_s`     |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
@@ -176,12 +176,10 @@
 | `i32x4.widen_low_i16x8_u`  |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 | `i32x4.widen_high_i16x8_u` |               `-msimd128` |    :heavy_check_mark: | :heavy_check_mark: |                    |
 
-[1] Tip of tree LLVM as of March 23, 2020
+[1] Tip of tree LLVM as of May 6, 2020
 
-[2] Tested on V8 8.1.0 (candidate). Requires flag `--experimental-wasm-simd`
+[2] Tested on V8 8.4.272. Requires flag `--experimental-wasm-simd`
 
 [3] Tip of tree WAVM as of Feb 16, 2020. Requires flag `--enable simd`
 
 [4] Requires (case-insensitive) flag `-wasmsimd`
-
-[5] Uses older `v8x16.shuffle` opcode `0xfd 0x03`


### PR DESCRIPTION
Updates based on latest LLVM & latest v8 (earlier v8 versions aren't
useful because of renumbering anyway):

- v8 implements load_splat and load with zero/sign extension
- v8 implements i64x2_mul
- v8 implements swizzle and andnot
- LLVM supports integer abs instructions and intrinsics
- Removing note about shuffle opcode - irrelevant post-renumbering

Notable remaining omissions:

- v8 doesn't implement v128.const
- LLVM doesn't implement (or at least doesn't expose an intrinsic for)
i64x2_mul
- A lot of instructions are still part of unimplemented subset in LLVM