### PR TITLE
v128.load32_zero and v128.load64_zero instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -222,3 +222,5 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
+| `v128.load32_zero`         |    `0xfc`| -                  |
+| `v128.load64_zero`         |    `0xfd`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -190,6 +190,8 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `v128.load32_zero`         |                           |                    |                    |                    |                    |
+| `v128.load64_zero`         |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -12,6 +12,8 @@
 | v128.load32_splat  | 0x09   |
 | v128.load64_splat  | 0x0a   |
 | v128.store         | 0x0b   |
+| v128.load32_zero   | 0xfc   |
+| v128.load64_zero   | 0xfd   |
 
 | Basic operation | opcode |
 | ----------------| ------ |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -766,6 +766,24 @@ def S.load(memarg):
     return S.from_bytes(memory[memarg.offset:memarg.offset + 16])
 ```
 
+### Load and Zero-Pad
+
+* `v128.load32_zero(memarg) -> v128`
+* `v128.load64_zero(memarg) -> v128`
+
+Load a single 32-bit or 64-bit element into the lowest bits of a `v128` vector,
+and initialize all other bits of the `v128` vector to zero.
+
+```python
+def S.load32_zero(memarg):
+    return S.from_bytes(memory[memarg.offset:memarg.offset + 4])
+```
+
+```python
+def S.load64_zero(memarg):
+    return S.from_bytes(memory[memarg.offset:memarg.offset + 8])
+```
+
 ### Load and Splat
 
 * `v128.load8_splat(memarg) -> v128`


### PR DESCRIPTION
Introduction
=========

This PR introduce two new variants of load instructions which load a **single** 32-bit or 64-bit element into the lowest part of 128-bit SIMD vector and zero-extend it to full 128 bits. These instructions natively map to SSE2 and ARM64 NEON instruction, and have two broad use-cases:
1. Non-contiguous loads, when we need to combine elements from disjoint locations in a single SIMD vector. Non-contiguous loads are commonly emulated by doing loads a single elements and then combining the values through shuffles. While is it possible to do through a combination of scalar loads and `v128.replace_lane` instructions, the resulting code would use be inefficient in using too many general-purpose registers, producing an overly long dependency chain (every `v128.replace_lane` depends on the previous one), and hitting the long-latency/low-throughput instructions to copy from general-purpose registers to SIMD registers. Non-contiguous loads using the proposed `v128.load32_zero` and `v128.load64_zero` instructions avoid all these bottlenecks.
2. Processing fewer than 128 bits of data. Sometimes the algorithm or data structures just don't expose enough data to utilize all 128 bits of a SIMD vector, but would nevertheless benefit from processing fewer elements in parallel (e.g. adding 8 bytes in one SIMD instruction rather than eight scalar instructions).

Applications
=========

- [libgav1 (AV1 decoder)](https://chromium.googlesource.com/codecs/libgav1/+/df75e6a9e8e2032c9291d9f0aa2c7c8519adfbfe/src/dsp/x86/common_sse4.h#103)
- [x264 encoder: sum of transformed differences (processing less than 16 elements)](https://github.com/mirror/x264/blob/33f9e1474613f59392be5ab6a7e7abf60fa63622/common/x86/pixel-32.asm#L86-L89)
- [x264 encoder: deblocking (non-contiguous load)](https://github.com/mirror/x264/blob/33f9e1474613f59392be5ab6a7e7abf60fa63622/common/x86/deblock-a.asm#L157-L164)
- [QDPXX/libintrin: matrix-vector multiplication (non-contiguous load)](https://github.com/usqcd-software/libintrin/blob/6e429e4c32b5099546dce833294781255b4c54a7/lib/sse_mult_adj_su3_mat_4vec.c)
- [QNNPACK: depthwise convolution (processing less than 8 elements)](https://github.com/pytorch/QNNPACK/blob/901e9d40aeedb2c1b212b28f022fb099ffe617c2/src/q8dwconv/mp8x25-sse2.c#L49)
- [cpp Wilson Dslash (non-contiguous load)](https://github.com/JeffersonLab/cpp_wilson_dslash/blob/56a4abf64c4d586a73bc2fd7747067f6e92329c9/include/cpp_dslash_parscalar_mvv_recons_32bit_sse2.h#L45-L53)
- [GROMACS: matrix transpose (non-contiguous load)](https://github.com/gromacs/gromacs/blob/a68cc20fd27a3cbebbc7c7cf563fcfb558f1feca/src/gromacs/simd/impl_x86_sse2/impl_x86_sse2_util_double.h#L101-L102)
- [OpenBLAS: matrix-matrix multiplication](https://github.com/xianyi/OpenBLAS/blob/ce3651516f12079f3ca2418aa85b9ad571c3a391/kernel/x86_64/cgemm_kernel_4x8_sandy.S#L158-L159)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **v128.load32_zero**
  - `v = v128.load32_zero(mem)` is lowered to `VMOVSS xmm_v, [mem]`
- **v128.load64_zero**
  - `v = v128.load64_zero(mem)` is lowered to `VMOVSD xmm_v, [mem]`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **v128.load32_zero**
  - `v = v128.load32_zero(mem)` is lowered to `MOVSS xmm_v, [mem]`
- **v128.load64_zero**
  - `v = v128.load64_zero(mem)` is lowered to `MOVSD xmm_v, [mem]`

ARM64 processors
--------------------------------------------------

- **v128.load32_zero**
  - `v = v128.load32_zero(mem)` is lowered to `LDR Sv, [mem]`
- **v128.load64_zero**
  - `v = v128.load64_zero(mem)` is lowered to `LDR Dv, [mem]`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **v128.load32_zero**
  - `v = v128.load32_zero(mem)` is lowered to `VMOV.I32 Qv, 0` + `VLD1.32 {Dv_lo[0]}, [mem]`
- **v128.load64_zero**
  - `v = v128.load64_zero(mem)` is lowered to `VMOV.I32 Dv_hi, 0` + `VLD1.32 {Dv_lo}, [mem]`
