### PR TITLE
Implement i32x4 neg add sub mul

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -127,12 +127,16 @@ struct
 
   let unop op =
     fun v -> match op with
+      | I32x4 Neg -> to_value (SXX.I32x4.neg (of_value 1 v))
       | F32x4 Abs -> to_value (SXX.F32x4.abs (of_value 1 v))
       | F64x2 Abs -> to_value (SXX.F64x2.abs (of_value 1 v))
       | _ -> failwith "TODO v128 unimplemented unop"
 
   let binop op =
     let f = match op with
+      | I32x4 Add -> SXX.I32x4.add
+      | I32x4 Sub -> SXX.I32x4.sub
+      | I32x4 Mul -> SXX.I32x4.mul
       | F32x4 Min -> SXX.F32x4.min
       | F32x4 Max -> SXX.F32x4.max
       | F64x2 Min -> SXX.F64x2.min

--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -40,6 +40,7 @@ sig
 
   val zero : t
 
+  val neg : t -> t
   val add : t -> t -> t
   val sub : t -> t -> t
   val mul : t -> t -> t
@@ -112,6 +113,8 @@ struct
   let zero = Rep.zero
   let one = Rep.one
   let ten = Rep.of_int 10
+
+  let neg = Rep.neg
 
   (* add, sub, and mul are sign-agnostic and do not trap on overflow. *)
   let add = Rep.add

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -375,6 +375,14 @@ let assert_result at got expect =
             let open Values in
             let open Simd in
             match shape, v with
+            | I32x4, V128 v ->
+                    let l0 = I32 (V128.I32x4.extract_lane 0 v) in
+                    let l1 = I32 (V128.I32x4.extract_lane 1 v) in
+                    let l2 = I32 (V128.I32x4.extract_lane 2 v) in
+                    let l3 = I32 (V128.I32x4.extract_lane 3 v) in
+                      List.exists2 (fun v r ->
+                          assert_num_pat at v r
+                      ) [l0; l1; l2; l3]  vs
             | F32x4, V128 v ->
                     let l0 = F32 (V128.F32x4.extract_lane 0 v) in
                     let l1 = F32 (V128.F32x4.extract_lane 1 v) in

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -47,8 +47,8 @@ end
 (* FIXME *)
 module SimdOp =
 struct
-  type iunop = TodoIunop
-  type ibinop = TodoIbinop
+  type iunop = Neg
+  type ibinop = Add | Sub | Mul
   type funop = Abs
   type fbinop = Min | Max
 

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -205,6 +205,10 @@ let memory_grow = MemoryGrow
 
 (* SIMD *)
 let i32x4_extract_lane imm = ExtractLane (V128Op.I32x4ExtractLane imm)
+let i32x4_neg = Unary (V128 (V128Op.I32x4 V128Op.Neg))
+let i32x4_add = Binary (V128 (V128Op.I32x4 V128Op.Add))
+let i32x4_sub = Binary (V128 (V128Op.I32x4 V128Op.Sub))
+let i32x4_mul = Binary (V128 (V128Op.I32x4 V128Op.Mul))
 
 let f32x4_extract_lane imm = ExtractLane (V128Op.F32x4ExtractLane imm)
 let f32x4_min = Binary (V128 (V128Op.F32x4 V128Op.Min))

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -380,6 +380,18 @@ rule token = parse
   | "input" { INPUT }
   | "output" { OUTPUT }
 
+  | (simd_shape as s)".neg"
+    { if s <> "i32x4" then error lexbuf "unknown operator";
+      UNARY (simdop s unreachable unreachable i32x4_neg unreachable unreachable unreachable) }
+  | (simd_shape as s)".add"
+    { if s <> "i32x4" then error lexbuf "unknown operator";
+      BINARY (simdop s unreachable unreachable i32x4_add unreachable unreachable unreachable) }
+  | (simd_shape as s)".sub"
+    { if s <> "i32x4" then error lexbuf "unknown operator";
+      BINARY (simdop s unreachable unreachable i32x4_sub unreachable unreachable unreachable) }
+  | (simd_shape as s)".mul"
+    { if s <> "i32x4" then error lexbuf "unknown operator";
+      BINARY (simdop s unreachable unreachable i32x4_mul unreachable unreachable unreachable) }
   | (simd_shape as s)".min"
     { if s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
       BINARY (simdop s unreachable unreachable unreachable unreachable f32x4_min f64x2_min) }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -58,9 +58,10 @@ let simd_lane_nan shape l at =
 let simd_lane_lit shape l at =
   let open Simd in
   match shape with
+  | I32x4 -> LitPat (Values.I32 (I32.of_string l) @@ at) @@ at
   | F32x4 -> LitPat (Values.F32 (F32.of_string l) @@ at) @@ at
   | F64x2 -> LitPat (Values.F64 (F64.of_string l) @@ at) @@ at
-  | _ -> error at "invalid simd constant"
+  | _ -> error at "unimplemented simd lane lit"
 
 let nanop f nan =
   let open Source in
@@ -880,11 +881,11 @@ result :
   | const { NumResult (LitPat $1 @@ at ()) @@ at () }
   | LPAR CONST NAN RPAR { NumResult (NanPat (nanop $2 ($3 @@ ati 3)) @@ ati 3) @@ at () }
   | LPAR V128_CONST SIMD_SHAPE numpat numpat numpat numpat RPAR {
-      if ($3 <> Simd.F32x4) then error (ati 3) "invalid SIMD shape";
+      if ($3 <> Simd.F32x4 && $3 <> Simd.I32x4) then error (ati 3) "unimplemented SIMD shape";
       SimdResult ($3, [$4 $3; $5 $3; $6 $3; $7 $3]) @@ at ()
   }
   | LPAR V128_CONST SIMD_SHAPE numpat numpat RPAR {
-      if ($3 <> Simd.F64x2) then error (ati 3) "invalid SIMD shape";
+      if ($3 <> Simd.F64x2) then error (ati 3) "unimplemented SIMD shape";
       SimdResult ($3, [$4 $3; $5 $3]) @@ at ()
   }
 


### PR DESCRIPTION
This required exposing neg from int.ml, to be used by simd.ml

Fixes to parsing of v128.const in assert_returns, to handle i32x4.

Handle matching i32x4 in script/run.ml.

With this, test/core/simd/simd_i32x4_arith.wast passes.