### PR TITLE
Fix: assert_return should use canonical NaN for comparison

### DIFF
--- a/test/core/simd/meta/simd_f64x2.py
+++ b/test/core/simd/meta/simd_f64x2.py
@@ -144,13 +144,13 @@ class Simdf64x2Case(Simdf32x4Case):
             [
                 'f64x2.min',
                 [['nan', '0'], ['0', '1']],
-                [['nan', '0']],
+                [['nan:canonical', '0']],
                 ['f64x2', 'f64x2', 'f64x2']
             ],
             [
                 'f64x2.min',
                 [['0', '1'], ['-nan', '0']],
-                [['-nan', '0']],
+                [['nan:canonical', '0']],
                 ['f64x2', 'f64x2', 'f64x2']
             ],
             [

--- a/test/core/simd/meta/simd_f64x2_arith.py
+++ b/test/core/simd/meta/simd_f64x2_arith.py
@@ -118,7 +118,7 @@ class Simdf64x2ArithmeticCase(Simdf32x4ArithmeticCase):
                 ('nan:arithmetic', '2.0'),
             ],
             'sub_arith': [
-                ('1.0', '-1.0'), ('-nan', '1.0'), ('nan', '-2.0'),
+                ('1.0', '-1.0'), ('-nan', '1.0'), ('nan:canonical', '-2.0'),
             ],
             'mul_mixed': [
                 ('nan:0x8000000000000', '1.0'), ('2.0', 'nan'),

--- a/test/core/simd/simd_f64x2.wast
+++ b/test/core/simd/simd_f64x2.wast
@@ -109,7 +109,7 @@
     (v128.const f64x2 nan 0)
     (v128.const f64x2 0 1)
   )
-  (v128.const f64x2 nan 0)
+  (v128.const f64x2 nan:canonical 0)
 )
 ;; f64x2.min
 (assert_return
@@ -117,7 +117,7 @@
     (v128.const f64x2 0 1)
     (v128.const f64x2 -nan 0)
   )
-  (v128.const f64x2 -nan 0)
+  (v128.const f64x2 nan:canonical 0)
 )
 ;; f64x2.min
 (assert_return

--- a/test/core/simd/simd_f64x2_arith.wast
+++ b/test/core/simd/simd_f64x2_arith.wast
@@ -5296,7 +5296,7 @@
 (assert_return (invoke "f64x2_mul_mixed") (v128.const f64x2 nan:arithmetic nan:canonical))
 (assert_return (invoke "f64x2_neg_canon") (v128.const f64x2 nan:canonical -1.0))
 (assert_return (invoke "f64x2_sqrt_canon") (v128.const f64x2 2.0 nan:canonical))
-(assert_return (invoke "f64x2_sub_arith") (v128.const f64x2 nan -2.0))
+(assert_return (invoke "f64x2_sub_arith") (v128.const f64x2 nan:canonical -2.0))
 
 ;; type check
 (assert_invalid (module (func (result v128) (f64x2.neg (i64.const 0)))) "type mismatch")


### PR DESCRIPTION
In running these tests, I discovered that they expected a specific NaN, not a canonical NaN, which causes errors if we always return a canonical NaN of a different sign. As @ngzhian pointed out in a separate conversation, the spec expects the returned value to be a canonical NaN: https://webassembly.github.io/spec/core/bikeshed/index.html#nan-propagation%E2%91%A0. 

@Honry, I don't know if any meta machinery needs to change to generate these files correctly but let me know and I can update the PR.

cc: @arunetm 