### PR TITLE
Update Firefox/SpiderMonkey status for .bitmask

### DIFF
--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -87,7 +87,7 @@
 | `i8x16.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `i8x16.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
+| `i8x16.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.narrow_i16x8_s`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.narrow_i16x8_u`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.shl`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -108,7 +108,7 @@
 | `i16x8.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `i16x8.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
+| `i16x8.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.narrow_i32x4_s`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.narrow_i32x4_u`     |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.widen_low_i8x16_s`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -134,7 +134,7 @@
 | `i32x4.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.any_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.all_true`           |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `i32x4.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    |                    |
+| `i32x4.bitmask`            | `-munimplemented-simd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.widen_low_i16x8_s`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.widen_high_i16x8_s` |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.widen_low_i16x8_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -187,4 +187,4 @@
 
 [4] Not known to be updated after latest renumbering. Requires (case-insensitive) flag `-wasmsimd`
 
-[5] FF78 Nightly x64 SSE4.1+ only, enabled by default, disable in about:config under `javascript.options.wasm_simd`
+[5] Firefox Nightly x64/x86 SSE4.1+ only, disable in about:config under `javascript.options.wasm_simd`


### PR DESCRIPTION
Landed support for 32-bit x86 + support for .bitmask instruction.