### PR TITLE
Create a helper to check valid simd operations

### DIFF
--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -114,6 +114,10 @@ let simd_shape = function
   | "f32x4" -> Simd.F32x4
   | "f64x2" -> Simd.F64x2
   | _ -> assert false
+
+let only shapes s lexbuf =
+  if not (List.mem s shapes) then
+    error lexbuf "unknown operator"
 }
 
 let sign = '+' | '-'
@@ -389,35 +393,35 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".neg"
-    { if s <> "i32x4" && s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
+    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
       UNARY (simdop s unreachable unreachable i32x4_neg unreachable f32x4_neg f64x2_neg) }
   | (simd_float_shape as s)".sqrt" { UNARY (simd_float_op s f32x4_sqrt f64x2_sqrt) }
   | (simd_shape as s)".add"
-    { if s <> "i32x4" && s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
+    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_add unreachable f32x4_add f64x2_add) }
   | (simd_shape as s)".sub"
-    { if s <> "i32x4" && s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
+    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_sub unreachable f32x4_sub f64x2_sub) }
   | (simd_shape as s)".min_s"
-    { if s <> "i32x4" then error lexbuf "unknown operator";
+    { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_min_s unreachable unreachable unreachable) }
   | (simd_shape as s)".min_u"
-    { if s <> "i32x4" then error lexbuf "unknown operator";
+    { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_min_u unreachable unreachable unreachable) }
   | (simd_shape as s)".max_s"
-    { if s <> "i32x4" then error lexbuf "unknown operator";
+    { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_max_s unreachable unreachable unreachable) }
   | (simd_shape as s)".max_u"
-    { if s <> "i32x4" then error lexbuf "unknown operator";
+    { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_max_u unreachable unreachable unreachable) }
   | (simd_shape as s)".mul"
-    { if s <> "i32x4" && s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
+    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_mul unreachable f32x4_mul f64x2_mul) }
   | (simd_float_shape as s)".div" { BINARY (simd_float_op s f32x4_div f64x2_div) }
   | (simd_float_shape as s)".min" { BINARY (simd_float_op s f32x4_min f64x2_min) }
   | (simd_float_shape as s)".max" { BINARY (simd_float_op s f32x4_max f64x2_max) }
   | (simd_shape as s)".abs"
-    { if s <> "i32x4" && s <> "f32x4" && s <> "f64x2" then error lexbuf "unknown operator";
+    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
       UNARY (simdop s unreachable unreachable i32x4_abs unreachable f32x4_abs f64x2_abs) }
   | (simd_shape as s) { SIMD_SHAPE (simd_shape s) }
 


### PR DESCRIPTION
The "i32x4" case looks trivial now, but we will be adding i64x2 later.