### PR TITLE
Support i16x8 and implement neg, add, sub, mul

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -127,6 +127,7 @@ struct
 
   let unop (op : unop) =
     fun v -> match op with
+      | I16x8 Neg -> to_value (SXX.I16x8.neg (of_value 1 v))
       | I32x4 Abs -> to_value (SXX.I32x4.abs (of_value 1 v))
       | I32x4 Neg -> to_value (SXX.I32x4.neg (of_value 1 v))
       | F32x4 Abs -> to_value (SXX.F32x4.abs (of_value 1 v))
@@ -139,6 +140,9 @@ struct
 
   let binop (op : binop) =
     let f = match op with
+      | I16x8 Add -> SXX.I16x8.add
+      | I16x8 Sub -> SXX.I16x8.sub
+      | I16x8 Mul -> SXX.I16x8.mul
       | I32x4 Add -> SXX.I32x4.add
       | I32x4 Sub -> SXX.I32x4.sub
       | I32x4 MinS -> SXX.I32x4.min_s

--- a/interpreter/exec/i16.ml
+++ b/interpreter/exec/i16.ml
@@ -1,0 +1,11 @@
+(* I16 for SIMD. Uses Int32 as the underlying storage. All int16 values will be
+ * stored signed-extended. E.g. -1 will be stored with all high bits set.
+ *)
+include Int.Make (struct
+  include Int32
+
+  let bitwidth = 16
+
+  let min_int = Int32.of_int (-32768)
+  let max_int = Int32.of_int 32767
+end)

--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -237,11 +237,9 @@ struct
     | 'A' .. 'F' as c ->  0xa + Char.code c - Char.code 'A'
     | _ ->  failwith "of_string"
 
-  let max_upper, max_lower =
-    let mup, mlow = divrem_u Rep.minus_one ten in
-    mup, mlow
+  let max_upper, max_lower = divrem_u Rep.minus_one ten
 
-  let maybe_sign_extend i =
+  let sign_extend i =
     (* This module is used with I32 and I64, but the bitwidth can be less
      * than that, e.g. for I16. When used for smaller integers, the stored value
      * needs to be signed extened, e.g. parsing -1 into a I16 (backed by Int32)
@@ -251,7 +249,7 @@ struct
      *   -1 (Int32) << 32 = -1
      * Then the logor will be also wrong. So we check and bail out early.
      * *)
-    if Rep.bitwidth >= 32 then i else
+    if Rep.add Rep.max_int Rep.one = Rep.min_int then i else
     let sign_bit = Rep.logand (Rep.of_int (1 lsl (Rep.bitwidth - 1))) i in
     if sign_bit = Rep.zero then i else
     (* Build a sign-extension mask *)
@@ -291,7 +289,7 @@ struct
         Rep.neg n
       | _ -> parse_int 0
     in
-    maybe_sign_extend parsed
+    sign_extend parsed
 
   let of_string_s s =
     let n = of_string s in

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -11,6 +11,7 @@ let lanes shape =
   | F32x4 -> 4
   | F64x2 -> 2
 
+let i16x8_indices = [0; 2; 4; 6; 8; 10; 12; 14]
 let i32x4_indices = [0; 4; 8; 12]
 let f32x4_indices = i32x4_indices
 let f64x2_indices = [0; 8]
@@ -24,6 +25,9 @@ sig
   val to_string : t -> string
   val bytewidth : int
   val of_strings : shape -> string list -> t
+
+  val to_i16x8 : t -> I16.t list
+  val of_i16x8 : I16.t list -> t
 
   val to_i32x4 : t -> I32.t list
   val of_i32x4 : I32.t list -> t
@@ -80,10 +84,12 @@ sig
   val of_bits : bits -> t
   val to_bits : t -> bits
   val of_strings : shape -> string list -> t
+  val to_i16x8 : t -> I16.t list
   val to_i32x4 : t -> I32.t list
 
   (* We need type t = t to ensure that all submodule types are S.t,
    * then callers don't have to change *)
+  module I16x8 : Int with type t = t and type lane = I16.t
   module I32x4 : Int with type t = t and type lane = I32.t
   module F32x4 : Float with type t = t and type lane = F32.t
   module F64x2 : Float with type t = t and type lane = F64.t
@@ -99,6 +105,7 @@ struct
   let of_bits x = x
   let to_bits x = x
   let of_strings = Rep.of_strings
+  let to_i16x8 = Rep.to_i16x8
   let to_i32x4 = Rep.to_i32x4
 
   module MakeFloat (Float : Float.S) (Convert : sig
@@ -143,6 +150,11 @@ struct
     let max_s = binop (choose Int.ge_s)
     let max_u = binop (choose Int.ge_u)
   end
+
+  module I16x8 = MakeInt (I16) (struct
+      let to_shape = Rep.to_i16x8
+      let of_shape = Rep.of_i16x8
+    end)
 
   module I32x4 = MakeInt (I32) (struct
       let to_shape = Rep.to_i32x4

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -4,6 +4,14 @@ include Simd.Make
     let bytewidth = 16
     let to_string s = s
 
+    let to_i16x8 s =
+      List.map (fun i -> I16.of_bits (Int32.of_int (Bytes.get_int16_le (Bytes.of_string s) i))) Simd.i16x8_indices
+
+    let of_i16x8 fs =
+      let b = Bytes.create bytewidth in
+      List.iter2 (fun i f -> Bytes.set_int16_le b i (Int32.to_int (I16.to_bits f))) Simd.i16x8_indices fs;
+      Bytes.to_string b
+
     let to_i32x4 s =
       List.map (fun i -> I32.of_bits (Bytes.get_int32_le (Bytes.of_string s) i)) Simd.f32x4_indices
 
@@ -42,7 +50,7 @@ include Simd.Make
       | Simd.I8x16 ->
         List.iteri (fun i s -> set_uint8 b i (i8_of_string s)) ss
       | Simd.I16x8 ->
-        List.iteri (fun i s -> set_uint16_le b (i * 2) (i16_of_string s)) ss
+        List.iteri (fun i s -> set_int16_le b (i * 2) (i16_of_string s)) ss
       | Simd.I32x4 ->
         List.iteri (fun i s -> set_int32_le b (i * 4) (I32.of_string s)) ss
       | Simd.I64x2 ->

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -375,6 +375,11 @@ let assert_result at got expect =
             let open Values in
             let open Simd in
             match shape, v with
+            | I16x8, V128 v ->
+              List.exists2
+                (fun v r -> assert_num_pat at v r)
+                (List.mapi (fun i x -> I32 (V128.I16x8.extract_lane i v)) i16x8_indices)
+                vs
             | I32x4, V128 v ->
               let l0 = I32 (V128.I32x4.extract_lane 0 v) in
               let l1 = I32 (V128.I32x4.extract_lane 1 v) in

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -204,6 +204,11 @@ let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
 (* SIMD *)
+let i16x8_neg = Unary (V128 (V128Op.I16x8 V128Op.Neg))
+let i16x8_add = Binary (V128 (V128Op.I16x8 V128Op.Add))
+let i16x8_sub = Binary (V128 (V128Op.I16x8 V128Op.Sub))
+let i16x8_mul = Binary (V128 (V128Op.I16x8 V128Op.Mul))
+
 let i32x4_extract_lane imm = ExtractLane (V128Op.I32x4ExtractLane imm)
 let i32x4_abs = Unary (V128 (V128Op.I32x4 V128Op.Abs))
 let i32x4_neg = Unary (V128 (V128Op.I32x4 V128Op.Neg))

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -393,15 +393,15 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".neg"
-    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      UNARY (simdop s unreachable unreachable i32x4_neg unreachable f32x4_neg f64x2_neg) }
+    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
+      UNARY (simdop s unreachable i16x8_neg i32x4_neg unreachable f32x4_neg f64x2_neg) }
   | (simd_float_shape as s)".sqrt" { UNARY (simd_float_op s f32x4_sqrt f64x2_sqrt) }
   | (simd_shape as s)".add"
-    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s unreachable unreachable i32x4_add unreachable f32x4_add f64x2_add) }
+    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
+      BINARY (simdop s unreachable i16x8_add i32x4_add unreachable f32x4_add f64x2_add) }
   | (simd_shape as s)".sub"
-    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s unreachable unreachable i32x4_sub unreachable f32x4_sub f64x2_sub) }
+    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
+      BINARY (simdop s unreachable i16x8_sub i32x4_sub unreachable f32x4_sub f64x2_sub) }
   | (simd_shape as s)".min_s"
     { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_min_s unreachable unreachable unreachable) }
@@ -415,8 +415,8 @@ rule token = parse
     { only ["i32x4"] s lexbuf;
       BINARY (simdop s unreachable unreachable i32x4_max_u unreachable unreachable unreachable) }
   | (simd_shape as s)".mul"
-    { only ["i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s unreachable unreachable i32x4_mul unreachable f32x4_mul f64x2_mul) }
+    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
+      BINARY (simdop s unreachable i16x8_mul i32x4_mul unreachable f32x4_mul f64x2_mul) }
   | (simd_float_shape as s)".div" { BINARY (simd_float_op s f32x4_div f64x2_div) }
   | (simd_float_shape as s)".min" { BINARY (simd_float_op s f32x4_min f64x2_min) }
   | (simd_float_shape as s)".max" { BINARY (simd_float_op s f32x4_max f64x2_max) }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -58,6 +58,7 @@ let simd_lane_nan shape l at =
 let simd_lane_lit shape l at =
   let open Simd in
   match shape with
+  | I16x8 -> LitPat (Values.I32 (I16.of_string l) @@ at) @@ at
   | I32x4 -> LitPat (Values.I32 (I32.of_string l) @@ at) @@ at
   | F32x4 -> LitPat (Values.F32 (F32.of_string l) @@ at) @@ at
   | F64x2 -> LitPat (Values.F64 (F64.of_string l) @@ at) @@ at
@@ -887,7 +888,7 @@ result :
   | LPAR V128_CONST SIMD_SHAPE numpat_list RPAR {
     if Simd.lanes $3 <> List.length $4 then error (at ()) "wrong number of lane literals";
     match $3 with
-    | Simd.I32x4 | Simd.F32x4 | Simd.F64x2 ->
+    | Simd.I16x8 | Simd.I32x4 | Simd.F32x4 | Simd.F64x2 ->
       SimdResult ($3, List.map (fun lit -> lit $3) ($4)) @@ at ()
     | _ -> error (ati 3) "unimplemented SIMD shape"
   }


### PR DESCRIPTION
Create a new module I16, which uses Int.Make, and is backed by Int32. It
reuses a bunch of logic in Int. It stores 16-bit integers sign-extended
in Int32. This means that -1 (0xFFFF) is stored as 0xFFFFFFFF, rather
than 0x0000FFFF. All the bytes decode/encode logic is also done using
the signed form.