### PR TITLE
Implement 8x16 abs, min_{s,u}, max_{s,u}, avgr_u

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -129,6 +129,7 @@ struct
   let unop (op : unop) =
     fun v -> match op with
       | I8x16 Neg -> to_value (SXX.I8x16.neg (of_value 1 v))
+      | I8x16 Abs -> to_value (SXX.I8x16.abs (of_value 1 v))
       | I16x8 Neg -> to_value (SXX.I16x8.neg (of_value 1 v))
       | I16x8 Abs -> to_value (SXX.I16x8.abs (of_value 1 v))
       | I32x4 Abs -> to_value (SXX.I32x4.abs (of_value 1 v))
@@ -145,6 +146,11 @@ struct
     let f = match op with
       | I8x16 Add -> SXX.I8x16.add
       | I8x16 Sub -> SXX.I8x16.sub
+      | I8x16 MinS -> SXX.I8x16.min_s
+      | I8x16 MinU -> SXX.I8x16.min_u
+      | I8x16 MaxS -> SXX.I8x16.max_s
+      | I8x16 MaxU -> SXX.I8x16.max_u
+      | I8x16 AvgrU -> SXX.I8x16.avgr_u
       | I16x8 Add -> SXX.I16x8.add
       | I16x8 Sub -> SXX.I16x8.sub
       | I16x8 Mul -> SXX.I16x8.mul

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -220,6 +220,12 @@ let memory_grow = MemoryGrow
 let i8x16_neg = Unary (V128 (V128Op.I8x16 V128Op.Neg))
 let i8x16_add = Binary (V128 (V128Op.I8x16 V128Op.Add))
 let i8x16_sub = Binary (V128 (V128Op.I8x16 V128Op.Sub))
+let i8x16_abs = Unary (V128 (V128Op.I8x16 V128Op.Abs))
+let i8x16_min_s = Binary (V128 (V128Op.I8x16 V128Op.MinS))
+let i8x16_min_u = Binary (V128 (V128Op.I8x16 V128Op.MinU))
+let i8x16_max_s = Binary (V128 (V128Op.I8x16 V128Op.MaxS))
+let i8x16_max_u = Binary (V128 (V128Op.I8x16 V128Op.MaxU))
+let i8x16_avgr_u = Binary (V128 (V128Op.I8x16 V128Op.AvgrU))
 
 let i16x8_neg = Unary (V128 (V128Op.I16x8 V128Op.Neg))
 let i16x8_add = Binary (V128 (V128Op.I16x8 V128Op.Add))

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -422,17 +422,17 @@ rule token = parse
     { only ["i8x16"; "i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
       BINARY (simdop s i8x16_sub i16x8_sub i32x4_sub unreachable f32x4_sub f64x2_sub) }
   | (simd_shape as s)".min_s"
-    { only ["i16x8"; "i32x4"] s lexbuf;
-      BINARY (simdop s unreachable i16x8_min_s i32x4_min_s unreachable unreachable unreachable) }
+    { only ["i8x16"; "i16x8"; "i32x4"] s lexbuf;
+      BINARY (simdop s i8x16_min_s i16x8_min_s i32x4_min_s unreachable unreachable unreachable) }
   | (simd_shape as s)".min_u"
-    { only ["i16x8"; "i32x4"] s lexbuf;
-      BINARY (simdop s unreachable i16x8_min_u i32x4_min_u unreachable unreachable unreachable) }
+    { only ["i8x16"; "i16x8"; "i32x4"] s lexbuf;
+      BINARY (simdop s i8x16_min_u i16x8_min_u i32x4_min_u unreachable unreachable unreachable) }
   | (simd_shape as s)".max_s"
-    { only ["i16x8"; "i32x4"] s lexbuf;
-      BINARY (simdop s unreachable i16x8_max_s i32x4_max_s unreachable unreachable unreachable) }
+    { only ["i8x16"; "i16x8"; "i32x4"] s lexbuf;
+      BINARY (simdop s i8x16_max_s i16x8_max_s i32x4_max_s unreachable unreachable unreachable) }
   | (simd_shape as s)".max_u"
-    { only ["i16x8"; "i32x4"] s lexbuf;
-      BINARY (simdop s unreachable i16x8_max_u i32x4_max_u unreachable unreachable unreachable) }
+    { only ["i8x16"; "i16x8"; "i32x4"] s lexbuf;
+      BINARY (simdop s i8x16_max_u i16x8_max_u i32x4_max_u unreachable unreachable unreachable) }
   | (simd_shape as s)".mul"
     { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
       BINARY (simdop s unreachable i16x8_mul i32x4_mul unreachable f32x4_mul f64x2_mul) }
@@ -440,11 +440,11 @@ rule token = parse
   | (simd_float_shape as s)".min" { BINARY (simd_float_op s f32x4_min f64x2_min) }
   | (simd_float_shape as s)".max" { BINARY (simd_float_op s f32x4_max f64x2_max) }
   | (simd_shape as s)".abs"
-    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      UNARY (simdop s unreachable i16x8_abs i32x4_abs unreachable f32x4_abs f64x2_abs) }
+    { only ["i8x16"; "i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
+      UNARY (simdop s i8x16_abs i16x8_abs i32x4_abs unreachable f32x4_abs f64x2_abs) }
   | (simd_int_shape as s)".avgr_u"
-    { only ["i16x8"] s lexbuf;
-      UNARY (simd_int_op s unreachable i16x8_avgr_u unreachable unreachable) }
+    { only ["i8x16"; "i16x8"] s lexbuf;
+      UNARY (simd_int_op s i8x16_avgr_u i16x8_avgr_u unreachable unreachable) }
   | (simd_shape as s) { SIMD_SHAPE (simd_shape s) }
 
   | name as s { VAR s }


### PR DESCRIPTION
This passes simd_i8x16_arith2.wast.