### PR TITLE
Support I64x2

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -133,6 +133,7 @@ struct
       | I16x8 Abs -> to_value (SXX.I16x8.abs (of_value 1 v))
       | I32x4 Abs -> to_value (SXX.I32x4.abs (of_value 1 v))
       | I32x4 Neg -> to_value (SXX.I32x4.neg (of_value 1 v))
+      | I64x2 Neg -> to_value (SXX.I64x2.neg (of_value 1 v))
       | F32x4 Abs -> to_value (SXX.F32x4.abs (of_value 1 v))
       | F32x4 Neg -> to_value (SXX.F32x4.neg (of_value 1 v))
       | F32x4 Sqrt -> to_value (SXX.F32x4.sqrt (of_value 1 v))
@@ -160,6 +161,9 @@ struct
       | I32x4 MaxS -> SXX.I32x4.max_s
       | I32x4 MaxU -> SXX.I32x4.max_u
       | I32x4 Mul -> SXX.I32x4.mul
+      | I64x2 Add -> SXX.I64x2.add
+      | I64x2 Sub -> SXX.I64x2.sub
+      | I64x2 Mul -> SXX.I64x2.mul
       | F32x4 Add -> SXX.F32x4.add
       | F32x4 Sub -> SXX.F32x4.sub
       | F32x4 Mul -> SXX.F32x4.mul

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -30,6 +30,9 @@ sig
   val to_i32x4 : t -> I32.t list
   val of_i32x4 : I32.t list -> t
 
+  val to_i64x2 : t -> I64.t list
+  val of_i64x2 : I64.t list -> t
+
   val to_f32x4 : t -> F32.t list
   val of_f32x4 : F32.t list -> t
 
@@ -91,6 +94,7 @@ sig
   module I8x16 : Int with type t = t and type lane = I8.t
   module I16x8 : Int with type t = t and type lane = I16.t
   module I32x4 : Int with type t = t and type lane = I32.t
+  module I64x2 : Int with type t = t and type lane = I64.t
   module F32x4 : Float with type t = t and type lane = F32.t
   module F64x2 : Float with type t = t and type lane = F64.t
 end
@@ -167,6 +171,11 @@ struct
   module I32x4 = MakeInt (I32) (struct
       let to_shape = Rep.to_i32x4
       let of_shape = Rep.of_i32x4
+    end)
+
+  module I64x2 = MakeInt (I64) (struct
+      let to_shape = Rep.to_i64x2
+      let of_shape = Rep.of_i64x2
     end)
 
   module F32x4 = MakeFloat (F32) (struct

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -28,6 +28,14 @@ include Simd.Make
       List.iteri (fun i f -> Bytes.set_int32_le b (i*4) (I32.to_bits f)) fs;
       Bytes.to_string b
 
+    let to_i64x2 s =
+      List.init 2 (fun i -> I64.of_bits (Bytes.get_int64_le (Bytes.of_string s) (i*8)))
+
+    let of_i64x2 fs =
+      let b = Bytes.create bytewidth in
+      List.iteri (fun i f -> Bytes.set_int64_le b (i*8) (I64.to_bits f)) fs;
+      Bytes.to_string b
+
     let to_f32x4 s =
       List.init 4 (fun i -> F32.of_bits (Bytes.get_int32_le (Bytes.of_string s) (i*4)))
 

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -393,6 +393,11 @@ let assert_result at got expect =
                 List.exists2 (fun v r ->
                     assert_num_pat at v r
                 ) [l0; l1; l2; l3]  vs
+            | I64x2, V128 v ->
+              List.exists2
+                (fun v r -> assert_num_pat at v r)
+                (List.init 2 (fun i -> I64 (V128.I64x2.extract_lane i v)))
+                vs
             | F32x4, V128 v ->
               let l0 = F32 (V128.F32x4.extract_lane 0 v) in
               let l1 = F32 (V128.F32x4.extract_lane 1 v) in

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -243,6 +243,11 @@ let i32x4_max_s = Binary (V128 (V128Op.I32x4 V128Op.MaxS))
 let i32x4_max_u = Binary (V128 (V128Op.I32x4 V128Op.MaxU))
 let i32x4_mul = Binary (V128 (V128Op.I32x4 V128Op.Mul))
 
+let i64x2_neg = Unary (V128 (V128Op.I64x2 V128Op.Neg))
+let i64x2_add = Binary (V128 (V128Op.I64x2 V128Op.Add))
+let i64x2_sub = Binary (V128 (V128Op.I64x2 V128Op.Sub))
+let i64x2_mul = Binary (V128 (V128Op.I64x2 V128Op.Mul))
+
 let f32x4_extract_lane imm = ExtractLane (V128Op.F32x4ExtractLane imm)
 let f32x4_abs = Unary (V128 (V128Op.F32x4 V128Op.Abs))
 let f32x4_neg = Unary (V128 (V128Op.F32x4 V128Op.Neg))

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -412,15 +412,12 @@ rule token = parse
   | "output" { OUTPUT }
 
   | (simd_shape as s)".neg"
-    { only ["i8x16"; "i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      UNARY (simdop s i8x16_neg i16x8_neg i32x4_neg unreachable f32x4_neg f64x2_neg) }
+    { UNARY (simdop s i8x16_neg i16x8_neg i32x4_neg i64x2_neg f32x4_neg f64x2_neg) }
   | (simd_float_shape as s)".sqrt" { UNARY (simd_float_op s f32x4_sqrt f64x2_sqrt) }
   | (simd_shape as s)".add"
-    { only ["i8x16"; "i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s i8x16_add i16x8_add i32x4_add unreachable f32x4_add f64x2_add) }
+    { BINARY (simdop s i8x16_add i16x8_add i32x4_add i64x2_add f32x4_add f64x2_add) }
   | (simd_shape as s)".sub"
-    { only ["i8x16"; "i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s i8x16_sub i16x8_sub i32x4_sub unreachable f32x4_sub f64x2_sub) }
+    { BINARY (simdop s i8x16_sub i16x8_sub i32x4_sub i64x2_sub f32x4_sub f64x2_sub) }
   | (simd_shape as s)".min_s"
     { only ["i16x8"; "i32x4"] s lexbuf;
       BINARY (simdop s unreachable i16x8_min_s i32x4_min_s unreachable unreachable unreachable) }
@@ -434,8 +431,8 @@ rule token = parse
     { only ["i16x8"; "i32x4"] s lexbuf;
       BINARY (simdop s unreachable i16x8_max_u i32x4_max_u unreachable unreachable unreachable) }
   | (simd_shape as s)".mul"
-    { only ["i16x8"; "i32x4"; "f32x4"; "f64x2"] s lexbuf;
-      BINARY (simdop s unreachable i16x8_mul i32x4_mul unreachable f32x4_mul f64x2_mul) }
+    { only ["i16x8"; "i32x4"; "i64x2"; "f32x4"; "f64x2"] s lexbuf;
+      BINARY (simdop s unreachable i16x8_mul i32x4_mul i64x2_mul f32x4_mul f64x2_mul) }
   | (simd_float_shape as s)".div" { BINARY (simd_float_op s f32x4_div f64x2_div) }
   | (simd_float_shape as s)".min" { BINARY (simd_float_op s f32x4_min f64x2_min) }
   | (simd_float_shape as s)".max" { BINARY (simd_float_op s f32x4_max f64x2_max) }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -61,9 +61,9 @@ let simd_lane_lit shape l at =
   | I8x16 -> LitPat (Values.I32 (I8.of_string l) @@ at) @@ at
   | I16x8 -> LitPat (Values.I32 (I16.of_string l) @@ at) @@ at
   | I32x4 -> LitPat (Values.I32 (I32.of_string l) @@ at) @@ at
+  | I64x2 -> LitPat (Values.I64 (I64.of_string l) @@ at) @@ at
   | F32x4 -> LitPat (Values.F32 (F32.of_string l) @@ at) @@ at
   | F64x2 -> LitPat (Values.F64 (F64.of_string l) @@ at) @@ at
-  | _ -> error at "unimplemented simd lane lit"
 
 let nanop f nan =
   let open Source in
@@ -933,10 +933,7 @@ result :
   | LPAR CONST NAN RPAR { NumResult (NanPat (nanop $2 ($3 @@ ati 3)) @@ ati 3) @@ at () }
   | LPAR V128_CONST SIMD_SHAPE numpat_list RPAR {
     if Simd.lanes $3 <> List.length $4 then error (at ()) "wrong number of lane literals";
-    match $3 with
-    | Simd.I8x16 | Simd.I16x8 | Simd.I32x4 | Simd.F32x4 | Simd.F64x2 ->
-      SimdResult ($3, List.map (fun lit -> lit $3) ($4)) @@ at ()
-    | _ -> error (ati 3) "unimplemented SIMD shape"
+    SimdResult ($3, List.map (fun lit -> lit $3) ($4)) @@ at ()
   }
 
 result_list :


### PR DESCRIPTION
Add i64x2.{neg,add,sub,mul}, now simd/simd_i64x2_arith.wast passes.