### PR TITLE
Implement v128 bitwise operations

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -132,6 +132,7 @@ struct
       | I8x16 Abs -> to_value (SXX.I8x16.abs (of_value 1 v))
       | I16x8 Neg -> to_value (SXX.I16x8.neg (of_value 1 v))
       | I16x8 Abs -> to_value (SXX.I16x8.abs (of_value 1 v))
+      | I32x4 Not -> to_value (SXX.I32x4.lognot (of_value 1 v))
       | I32x4 Abs -> to_value (SXX.I32x4.abs (of_value 1 v))
       | I32x4 Neg -> to_value (SXX.I32x4.neg (of_value 1 v))
       | I64x2 Neg -> to_value (SXX.I64x2.neg (of_value 1 v))
@@ -160,6 +161,10 @@ struct
       | I16x8 MaxS -> SXX.I16x8.max_s
       | I16x8 MaxU -> SXX.I16x8.max_u
       | I16x8 AvgrU -> SXX.I16x8.avgr_u
+      | I32x4 And -> SXX.I32x4.logand
+      | I32x4 Or -> SXX.I32x4.or_
+      | I32x4 Xor -> SXX.I32x4.xor
+      | I32x4 Andnot -> SXX.I32x4.andnot
       | I32x4 Add -> SXX.I32x4.add
       | I32x4 Sub -> SXX.I32x4.sub
       | I32x4 MinS -> SXX.I32x4.min_s

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -186,7 +186,7 @@ struct
       | V128x1 And -> SXX.V128x1.and_
       | V128x1 Or -> SXX.V128x1.or_
       | V128x1 Xor -> SXX.V128x1.xor
-      | V128x1 Andnot -> SXX.V128x1.andnot
+      | V128x1 AndNot -> SXX.V128x1.andnot
       | _ -> failwith "TODO v128 unimplemented binop"
     in fun v1 v2 -> to_value (f (of_value 1 v1) (of_value 2 v2))
 

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -132,7 +132,6 @@ struct
       | I8x16 Abs -> to_value (SXX.I8x16.abs (of_value 1 v))
       | I16x8 Neg -> to_value (SXX.I16x8.neg (of_value 1 v))
       | I16x8 Abs -> to_value (SXX.I16x8.abs (of_value 1 v))
-      | I32x4 Not -> to_value (SXX.I32x4.lognot (of_value 1 v))
       | I32x4 Abs -> to_value (SXX.I32x4.abs (of_value 1 v))
       | I32x4 Neg -> to_value (SXX.I32x4.neg (of_value 1 v))
       | I64x2 Neg -> to_value (SXX.I64x2.neg (of_value 1 v))
@@ -142,6 +141,7 @@ struct
       | F64x2 Abs -> to_value (SXX.F64x2.abs (of_value 1 v))
       | F64x2 Neg -> to_value (SXX.F64x2.neg (of_value 1 v))
       | F64x2 Sqrt -> to_value (SXX.F64x2.sqrt (of_value 1 v))
+      | V128x1 Not -> to_value (SXX.V128x1.lognot (of_value 1 v))
       | _ -> failwith "TODO v128 unimplemented unop"
 
   let binop (op : binop) =
@@ -161,10 +161,6 @@ struct
       | I16x8 MaxS -> SXX.I16x8.max_s
       | I16x8 MaxU -> SXX.I16x8.max_u
       | I16x8 AvgrU -> SXX.I16x8.avgr_u
-      | I32x4 And -> SXX.I32x4.and_
-      | I32x4 Or -> SXX.I32x4.or_
-      | I32x4 Xor -> SXX.I32x4.xor
-      | I32x4 Andnot -> SXX.I32x4.andnot
       | I32x4 Add -> SXX.I32x4.add
       | I32x4 Sub -> SXX.I32x4.sub
       | I32x4 MinS -> SXX.I32x4.min_s
@@ -187,6 +183,10 @@ struct
       | F64x2 Div -> SXX.F64x2.div
       | F64x2 Min -> SXX.F64x2.min
       | F64x2 Max -> SXX.F64x2.max
+      | V128x1 And -> SXX.V128x1.and_
+      | V128x1 Or -> SXX.V128x1.or_
+      | V128x1 Xor -> SXX.V128x1.xor
+      | V128x1 Andnot -> SXX.V128x1.andnot
       | _ -> failwith "TODO v128 unimplemented binop"
     in fun v1 v2 -> to_value (f (of_value 1 v1) (of_value 2 v2))
 

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -141,7 +141,7 @@ struct
       | F64x2 Abs -> to_value (SXX.F64x2.abs (of_value 1 v))
       | F64x2 Neg -> to_value (SXX.F64x2.neg (of_value 1 v))
       | F64x2 Sqrt -> to_value (SXX.F64x2.sqrt (of_value 1 v))
-      | V128x1 Not -> to_value (SXX.V128x1.lognot (of_value 1 v))
+      | V128 Not -> to_value (SXX.V128.lognot (of_value 1 v))
       | _ -> failwith "TODO v128 unimplemented unop"
 
   let binop (op : binop) =
@@ -183,10 +183,10 @@ struct
       | F64x2 Div -> SXX.F64x2.div
       | F64x2 Min -> SXX.F64x2.min
       | F64x2 Max -> SXX.F64x2.max
-      | V128x1 And -> SXX.V128x1.and_
-      | V128x1 Or -> SXX.V128x1.or_
-      | V128x1 Xor -> SXX.V128x1.xor
-      | V128x1 AndNot -> SXX.V128x1.andnot
+      | V128 And -> SXX.V128.and_
+      | V128 Or -> SXX.V128.or_
+      | V128 Xor -> SXX.V128.xor
+      | V128 AndNot -> SXX.V128.andnot
       | _ -> failwith "TODO v128 unimplemented binop"
     in fun v1 v2 -> to_value (f (of_value 1 v1) (of_value 2 v2))
 

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -161,7 +161,7 @@ struct
       | I16x8 MaxS -> SXX.I16x8.max_s
       | I16x8 MaxU -> SXX.I16x8.max_u
       | I16x8 AvgrU -> SXX.I16x8.avgr_u
-      | I32x4 And -> SXX.I32x4.logand
+      | I32x4 And -> SXX.I32x4.and_
       | I32x4 Or -> SXX.I32x4.or_
       | I32x4 Xor -> SXX.I32x4.xor
       | I32x4 Andnot -> SXX.I32x4.andnot

--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -49,6 +49,7 @@ sig
 
   val zero : t
 
+  val lognot : t -> t
   val abs : t -> t
   val neg : t -> t
   val add : t -> t -> t
@@ -127,6 +128,7 @@ struct
   let one = Rep.one
   let ten = Rep.of_int 10
 
+  let lognot = Rep.lognot
   let abs = Rep.abs
   let neg = Rep.neg
 

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -47,6 +47,11 @@ sig
   type lane
 
   val extract_lane : int -> t -> lane
+  val lognot : t -> t
+  val logand : t -> t -> t
+  val or_ : t -> t -> t
+  val xor : t -> t -> t
+  val andnot : t -> t -> t
   val abs : t -> t
   val neg : t -> t
   val add : t -> t -> t
@@ -143,6 +148,11 @@ struct
     let extract_lane i s = List.nth (Convert.to_shape s) i
     let unop f x = Convert.of_shape (List.map f (Convert.to_shape x))
     let binop f x y = Convert.of_shape (List.map2 f (Convert.to_shape x) (Convert.to_shape y))
+    let lognot = unop Int.lognot
+    let logand = binop Int.and_
+    let or_ = binop Int.or_
+    let xor = binop Int.xor
+    let andnot = binop (fun x y -> Int.and_ x (Int.lognot y))
     let abs = unop Int.abs
     let neg = unop Int.neg
     let add = binop Int.add

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -108,7 +108,7 @@ sig
   module I64x2 : Int with type t = t and type lane = I64.t
   module F32x4 : Float with type t = t and type lane = F32.t
   module F64x2 : Float with type t = t and type lane = F64.t
-  module V128x1 : Vec with type t = t
+  module V128 : Vec with type t = t
 end
 
 module Make (Rep : RepType) : S with type bits = Rep.t =
@@ -124,7 +124,7 @@ struct
   let to_i16x8 = Rep.to_i16x8
   let to_i32x4 = Rep.to_i32x4
 
-  module V128x1 : Vec with type t = Rep.t = struct
+  module V128 : Vec with type t = Rep.t = struct
     type t = Rep.t
     let to_shape = Rep.to_i64x2
     let of_shape = Rep.of_i64x2

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -48,7 +48,7 @@ sig
 
   val extract_lane : int -> t -> lane
   val lognot : t -> t
-  val logand : t -> t -> t
+  val and_ : t -> t -> t
   val or_ : t -> t -> t
   val xor : t -> t -> t
   val andnot : t -> t -> t
@@ -149,7 +149,7 @@ struct
     let unop f x = Convert.of_shape (List.map f (Convert.to_shape x))
     let binop f x y = Convert.of_shape (List.map2 f (Convert.to_shape x) (Convert.to_shape y))
     let lognot = unop Int.lognot
-    let logand = binop Int.and_
+    let and_ = binop Int.and_
     let or_ = binop Int.or_
     let xor = binop Int.xor
     let andnot = binop (fun x y -> Int.and_ x (Int.lognot y))

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -48,21 +48,24 @@ end
 (* FIXME *)
 module SimdOp =
 struct
-  type iunop = Abs | Neg | Not
-  type ibinop = And | Or | Xor | Andnot | Add | Sub | MinS | MinU | MaxS | MaxU | Mul | AvgrU
+  type iunop = Abs | Neg
+  type ibinop = Add | Sub | MinS | MinU | MaxS | MaxU | Mul | AvgrU
   type funop = Abs | Neg | Sqrt
   type fbinop = Add | Sub | Mul | Div | Min | Max
+  type vunop = Not
+  type vbinop = And | Or | Xor | Andnot
 
-  type ('i8x16, 'i16x8, 'i32x4, 'i64x2, 'f32x4, 'f64x2) v128op =
+  type ('i8x16, 'i16x8, 'i32x4, 'i64x2, 'f32x4, 'f64x2, 'v128) v128op =
     | I8x16 of 'i8x16
     | I16x8 of 'i16x8
     | I32x4 of 'i32x4
     | I64x2 of 'i64x2
     | F32x4 of 'f32x4
     | F64x2 of 'f64x2
+    | V128x1 of 'v128
 
-  type unop = (iunop, iunop, iunop, iunop, funop, funop) v128op
-  type binop = (ibinop, ibinop, ibinop, ibinop, fbinop, fbinop) v128op
+  type unop = (iunop, iunop, iunop, iunop, funop, funop, vunop) v128op
+  type binop = (ibinop, ibinop, ibinop, ibinop, fbinop, fbinop, vbinop) v128op
   type testop = TodoTestOp
   type relop = TodoRelOp
   type cvtop = TodoCvtOp

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -48,8 +48,8 @@ end
 (* FIXME *)
 module SimdOp =
 struct
-  type iunop = Abs | Neg
-  type ibinop = Add | Sub | MinS | MinU | MaxS | MaxU | Mul | AvgrU
+  type iunop = Abs | Neg | Not
+  type ibinop = And | Or | Xor | Andnot | Add | Sub | MinS | MinU | MaxS | MaxU | Mul | AvgrU
   type funop = Abs | Neg | Sqrt
   type fbinop = Add | Sub | Mul | Div | Min | Max
 

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -53,7 +53,7 @@ struct
   type funop = Abs | Neg | Sqrt
   type fbinop = Add | Sub | Mul | Div | Min | Max
   type vunop = Not
-  type vbinop = And | Or | Xor | Andnot
+  type vbinop = And | Or | Xor | AndNot
 
   type ('i8x16, 'i16x8, 'i32x4, 'i64x2, 'f32x4, 'f64x2, 'v128) v128op =
     | I8x16 of 'i8x16

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -62,7 +62,7 @@ struct
     | I64x2 of 'i64x2
     | F32x4 of 'f32x4
     | F64x2 of 'f64x2
-    | V128x1 of 'v128
+    | V128 of 'v128
 
   type unop = (iunop, iunop, iunop, iunop, funop, funop, vunop) v128op
   type binop = (ibinop, ibinop, ibinop, ibinop, fbinop, fbinop, vbinop) v128op

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -217,11 +217,11 @@ let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
 (* SIMD *)
-let v128_not = Unary (V128 (V128Op.V128x1 V128Op.Not))
-let v128_and = Binary (V128 (V128Op.V128x1 V128Op.And))
-let v128_andnot = Binary (V128 (V128Op.V128x1 V128Op.AndNot))
-let v128_or = Binary (V128 (V128Op.V128x1 V128Op.Or))
-let v128_xor = Binary (V128 (V128Op.V128x1 V128Op.Xor))
+let v128_not = Unary (V128 (V128Op.V128 V128Op.Not))
+let v128_and = Binary (V128 (V128Op.V128 V128Op.And))
+let v128_andnot = Binary (V128 (V128Op.V128 V128Op.AndNot))
+let v128_or = Binary (V128 (V128Op.V128 V128Op.Or))
+let v128_xor = Binary (V128 (V128Op.V128 V128Op.Xor))
 
 let i8x16_neg = Unary (V128 (V128Op.I8x16 V128Op.Neg))
 let i8x16_add = Binary (V128 (V128Op.I8x16 V128Op.Add))

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -217,6 +217,12 @@ let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
 (* SIMD *)
+let v128_not = Unary (V128 (V128Op.I32x4 V128Op.Not))
+let v128_and = Binary (V128 (V128Op.I32x4 V128Op.And))
+let v128_andnot = Binary (V128 (V128Op.I32x4 V128Op.Andnot))
+let v128_or = Binary (V128 (V128Op.I32x4 V128Op.Or))
+let v128_xor = Binary (V128 (V128Op.I32x4 V128Op.Xor))
+
 let i8x16_neg = Unary (V128 (V128Op.I8x16 V128Op.Neg))
 let i8x16_add = Binary (V128 (V128Op.I8x16 V128Op.Add))
 let i8x16_sub = Binary (V128 (V128Op.I8x16 V128Op.Sub))

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -217,11 +217,11 @@ let memory_size = MemorySize
 let memory_grow = MemoryGrow
 
 (* SIMD *)
-let v128_not = Unary (V128 (V128Op.I32x4 V128Op.Not))
-let v128_and = Binary (V128 (V128Op.I32x4 V128Op.And))
-let v128_andnot = Binary (V128 (V128Op.I32x4 V128Op.Andnot))
-let v128_or = Binary (V128 (V128Op.I32x4 V128Op.Or))
-let v128_xor = Binary (V128 (V128Op.I32x4 V128Op.Xor))
+let v128_not = Unary (V128 (V128Op.V128x1 V128Op.Not))
+let v128_and = Binary (V128 (V128Op.V128x1 V128Op.And))
+let v128_andnot = Binary (V128 (V128Op.V128x1 V128Op.Andnot))
+let v128_or = Binary (V128 (V128Op.V128x1 V128Op.Or))
+let v128_xor = Binary (V128 (V128Op.V128x1 V128Op.Xor))
 
 let i8x16_neg = Unary (V128 (V128Op.I8x16 V128Op.Neg))
 let i8x16_add = Binary (V128 (V128Op.I8x16 V128Op.Add))

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -219,7 +219,7 @@ let memory_grow = MemoryGrow
 (* SIMD *)
 let v128_not = Unary (V128 (V128Op.V128x1 V128Op.Not))
 let v128_and = Binary (V128 (V128Op.V128x1 V128Op.And))
-let v128_andnot = Binary (V128 (V128Op.V128x1 V128Op.Andnot))
+let v128_andnot = Binary (V128 (V128Op.V128x1 V128Op.AndNot))
 let v128_or = Binary (V128 (V128Op.V128x1 V128Op.Or))
 let v128_xor = Binary (V128 (V128Op.V128x1 V128Op.Xor))
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -411,6 +411,16 @@ rule token = parse
   | "input" { INPUT }
   | "output" { OUTPUT }
 
+  | vxxx".not"
+    { UNARY v128_not }
+  | vxxx".and"
+    { UNARY v128_and }
+  | vxxx".andnot"
+    { UNARY v128_andnot }
+  | vxxx".or"
+    { UNARY v128_or }
+  | vxxx".xor"
+    { UNARY v128_xor }
   | (simd_shape as s)".neg"
     { UNARY (simdop s i8x16_neg i16x8_neg i32x4_neg i64x2_neg f32x4_neg f64x2_neg) }
   | (simd_float_shape as s)".sqrt" { UNARY (simd_float_op s f32x4_sqrt f64x2_sqrt) }


### PR DESCRIPTION
These are implemented in terms of I32x4 operations, since they are
shape agnostic.

Not, and, or, xor, andnot.