### PR TITLE
Add SIMD type and value

### DIFF
--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -21,7 +21,7 @@ Value Types
      \hex{7E} &\Rightarrow& \I64 \\ &&|&
      \hex{7D} &\Rightarrow& \F32 \\ &&|&
      \hex{7C} &\Rightarrow& \F64 \\ &&|&
-     \hex{7B} &\Rightarrow& \S128 \\
+     \hex{7B} &\Rightarrow& \V128 \\
    \end{array}
 
 .. note::

--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -20,7 +20,8 @@ Value Types
      \hex{7F} &\Rightarrow& \I32 \\ &&|&
      \hex{7E} &\Rightarrow& \I64 \\ &&|&
      \hex{7D} &\Rightarrow& \F32 \\ &&|&
-     \hex{7C} &\Rightarrow& \F64 \\
+     \hex{7C} &\Rightarrow& \F64 \\ &&|&
+     \hex{7B} &\Rightarrow& \S128 \\
    \end{array}
 
 .. note::

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -7,14 +7,14 @@ Runtime Structure
 :ref:`Store <store>`, :ref:`stack <stack>`, and other *runtime structure* forming the WebAssembly abstract machine, such as :ref:`values <syntax-val>` or :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary syntax.
 
 
-.. index:: ! value, constant, value type, integer, floating-point
+.. index:: ! value, constant, value type, integer, floating-point, fixed-width simd
    pair: abstract syntax; value
 .. _syntax-val:
 
 Values
 ~~~~~~
 
-WebAssembly computations manipulate *values* of the four basic :ref:`value types <syntax-valtype>`: :ref:`integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each, respectively.
+WebAssembly computations manipulate *values* of the five basic :ref:`value types <syntax-valtype>`: :ref:`integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each  respectively, and :ref: `SIMD data <syntax-simd>` of 128 bit width representing packed integers of floating-point values.
 
 In most places of the semantics, values of different types can occur.
 In order to avoid ambiguities, values are therefore represented with an abstract syntax that makes their type explicit.
@@ -26,7 +26,8 @@ It is convenient to reuse the same notation as for the |CONST| :ref:`instruction
      \I32.\CONST~\i32 \\&&|&
      \I64.\CONST~\i64 \\&&|&
      \F32.\CONST~\f32 \\&&|&
-     \F64.\CONST~\f64
+     \F64.\CONST~\f64 \\&&|&
+     \S128.\CONST~\s128
    \end{array}
 
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -7,7 +7,7 @@ Runtime Structure
 :ref:`Store <store>`, :ref:`stack <stack>`, and other *runtime structure* forming the WebAssembly abstract machine, such as :ref:`values <syntax-val>` or :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary syntax.
 
 
-.. index:: ! value, constant, value type, integer, floating-point, fixed-width simd
+.. index:: ! value, constant, value type, integer, floating-point, simd
    pair: abstract syntax; value
 .. _syntax-val:
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -14,7 +14,7 @@ Runtime Structure
 Values
 ~~~~~~
 
-WebAssembly computations manipulate *values* of the five basic :ref:`value types <syntax-valtype>`: :ref:`integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each  respectively, and :ref: `SIMD data <syntax-simd>` of 128 bit width representing packed integers of floating-point values.
+WebAssembly computations manipulate *values* of the five basic :ref:`value types <syntax-valtype>`: :ref:`integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each  respectively, and :ref:`SIMD data <syntax-simd>` of 128 bit width.
 
 In most places of the semantics, values of different types can occur.
 In order to avoid ambiguities, values are therefore represented with an abstract syntax that makes their type explicit.
@@ -27,7 +27,7 @@ It is convenient to reuse the same notation as for the |CONST| :ref:`instruction
      \I64.\CONST~\i64 \\&&|&
      \F32.\CONST~\f32 \\&&|&
      \F64.\CONST~\f64 \\&&|&
-     \S128.\CONST~\s128
+     \V128.\CONST~\i128
    \end{array}
 
 

--- a/document/core/intro/overview.rst
+++ b/document/core/intro/overview.rst
@@ -23,6 +23,13 @@ This language is structured around the following concepts.
   Instead, integers are interpreted by respective operations
   as either unsigned or signed in two’s complement representation.
 
+  In addition to the basic value types above, a single 128 bit wide
+  value type is added to represent different types of packed data.
+  The supported representations are 4 32 bit, or 2 64 bit
+  |IEEE754|_ numbers, or different widths of packed integer values
+  specifically two 64 bit integers, four 32 bit integers, eight
+  16 bit integers, or 16 8 bit integers.
+
 .. _instruction:
 
 **Instructions**

--- a/document/core/intro/overview.rst
+++ b/document/core/intro/overview.rst
@@ -25,10 +25,10 @@ This language is structured around the following concepts.
 
   In addition to the basic value types above, a single 128 bit wide
   value type is added to represent different types of packed data.
-  The supported representations are 4 32 bit, or 2 64 bit
+  The supported representations are 4 32-bit, or 2 64-bit
   |IEEE754|_ numbers, or different widths of packed integer values
-  specifically two 64 bit integers, four 32 bit integers, eight
-  16 bit integers, or 16 8 bit integers.
+  specifically 2 64-bit integers, 4 32-bit integers, 8
+  16-bit integers, or 16 8-bit integers.
 
 .. _instruction:
 

--- a/document/core/intro/overview.rst
+++ b/document/core/intro/overview.rst
@@ -23,8 +23,8 @@ This language is structured around the following concepts.
   Instead, integers are interpreted by respective operations
   as either unsigned or signed in two’s complement representation.
 
-  In addition to the basic value types above, a single 128 bit wide
-  value type is added to represent different types of packed data.
+  In addition to the basic value types above, there is a single 128 bit wide
+  value type representing different types of packed data.
   The supported representations are 4 32-bit, or 2 64-bit
   |IEEE754|_ numbers, or different widths of packed integer values
   specifically 2 64-bit integers, 4 32-bit integers, 8

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -22,7 +22,7 @@ Value Types
 .. math::
    \begin{array}{llll}
    \production{value type} & \valtype &::=&
-     \I32 ~|~ \I64 ~|~ \F32 ~|~ \F64 ~|~ \S128 \\
+     \I32 ~|~ \I64 ~|~ \F32 ~|~ \F64 ~|~ \V128 \\
    \end{array}
 
 The types |I32| and |I64| classify 32 and 64 bit integers, respectively.
@@ -31,7 +31,7 @@ Integers are not inherently signed or unsigned, their interpretation is determin
 The types |F32| and |F64| classify 32 and 64 bit floating-point data, respectively.
 They correspond to the respective binary floating-point representations, also known as *single* and *double* precision, as defined by the |IEEE754|_ standard (Section 3.3).
 
-The type |S128| corresponds to 128 bit packed integer or floating-point data. The packed data
+The type |V128| corresponds to 128 bit packed integer or floating-point data. The packed data
 can be interpreted as signed or unsigned integers, single or double precision floating-point
 values, or a single 128 bit type. The interpretation is determined by individual operations.
 
@@ -41,7 +41,7 @@ Conventions
 * The meta variable :math:`t` ranges over value types where clear from context.
 
 * The notation :math:`|t|` denotes the *bit width* of a value type.
-  That is, :math:`|\I32| = |\F32| = 32`, :math:`|\I64| = |\F64| = 64`, and :math:`|\S128| = 128`.
+  That is, :math:`|\I32| = |\F32| = 32`, :math:`|\I64| = |\F64| = 64`, and :math:`|\V128| = 128`.
 
 
 .. index:: ! result type, value type, instruction, execution, function

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -22,7 +22,7 @@ Value Types
 .. math::
    \begin{array}{llll}
    \production{value type} & \valtype &::=&
-     \I32 ~|~ \I64 ~|~ \F32 ~|~ \F64 \\
+     \I32 ~|~ \I64 ~|~ \F32 ~|~ \F64 ~|~ \S128 \\
    \end{array}
 
 The types |I32| and |I64| classify 32 and 64 bit integers, respectively.
@@ -31,13 +31,17 @@ Integers are not inherently signed or unsigned, their interpretation is determin
 The types |F32| and |F64| classify 32 and 64 bit floating-point data, respectively.
 They correspond to the respective binary floating-point representations, also known as *single* and *double* precision, as defined by the |IEEE754|_ standard (Section 3.3).
 
+The type |S128| corresponds to 128 bit packed integer or floating-point data. The packed data
+can be interpreted as signed or unsigned integers, single or double precision floating-point
+values, or a single 128 bit type. The interpretation is determined by individual operations.
+
 Conventions
 ...........
 
 * The meta variable :math:`t` ranges over value types where clear from context.
 
 * The notation :math:`|t|` denotes the *bit width* of a value type.
-  That is, :math:`|\I32| = |\F32| = 32` and :math:`|\I64| = |\F64| = 64`.
+  That is, :math:`|\I32| = |\F32| = 32`, :math:`|\I64| = |\F64| = 64`, and :math:`|\S128| = 128`.
 
 
 .. index:: ! result type, value type, instruction, execution, function

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -31,7 +31,7 @@ Integers are not inherently signed or unsigned, their interpretation is determin
 The types |F32| and |F64| classify 32 and 64 bit floating-point data, respectively.
 They correspond to the respective binary floating-point representations, also known as *single* and *double* precision, as defined by the |IEEE754|_ standard (Section 3.3).
 
-The type |V128| corresponds to 128 bit packed integer or floating-point data. The packed data
+The type |V128| corresponds to a 128 bit vector of packed integer or floating-point data. The packed data
 can be interpreted as signed or unsigned integers, single or double precision floating-point
 values, or a single 128 bit type. The interpretation is determined by individual operations.
 

--- a/document/core/syntax/values.rst
+++ b/document/core/syntax/values.rst
@@ -152,12 +152,12 @@ Conventions
 Fixed-Width SIMD
 ~~~~~~~~~~~~~~~~
 
-Fixed-width SIMD data represents packed integers, or floating-floating point values. The packed values of a given SIMD value must all be of the same type, these packed values can be any of the signed, unsigned integer types, and floating-point types ocurring in this proposal.
+Fixed-width SIMD data represents packed integers, or floating-point values. The packed values of a given SIMD value must all be of the same type, which can be any of the signed, unsigned integer types, and floating-point types ocurring in this proposal. The supported representations of the packed values are 4 32-bit, or 2 64-bit |IEEE754|_ numbers, or different widths of packed integer values specifically 2 64-bit integers, 4 32-bit integers, 8 16-bit integers, or 16 8-bit integers.
 
-The number of packed values :math:`p` can be determined by the bit width :math:`N` of the packed value type.
+The number of packed values defined here are lanes :`lanes` can be determined by the bit width :math:`N` of the packed value type.
 
 .. math::
-   p = 128/N
+   lanes = 128/N
 
 .. index:: ! name, byte, Unicode, UTF-8, character, binary format
    pair: abstract syntax; name

--- a/document/core/syntax/values.rst
+++ b/document/core/syntax/values.rst
@@ -145,6 +145,19 @@ Conventions
 
 * The meta variable :math:`z` ranges over floating-point values where clear from context.
 
+.. index:: ! simd, fixed-width, vector
+   pair: abstract syntax; packed simd number
+.. _syntax-simd:
+
+Fixed-Width SIMD
+~~~~~~~~~~~~~~~~
+
+Fixed-width SIMD data represents packed integers, or floating-floating point values. The packed values of a given SIMD value must all be of the same type, these packed values can be any of the signed, unsigned integer types, and floating-point types ocurring in this proposal.
+
+The number of packed values :math:`p` can be determined by the bit width :math:`N` of the packed value type.
+
+.. math::
+   p = 128/N
 
 .. index:: ! name, byte, Unicode, UTF-8, character, binary format
    pair: abstract syntax; name

--- a/document/core/syntax/values.rst
+++ b/document/core/syntax/values.rst
@@ -152,12 +152,7 @@ Conventions
 Fixed-Width SIMD
 ~~~~~~~~~~~~~~~~
 
-Fixed-width SIMD data represents packed integers, or floating-point values. The packed values of a given SIMD value must all be of the same type, which can be any of the signed, unsigned integer types, and floating-point types ocurring in this proposal. The supported representations of the packed values are 4 32-bit, or 2 64-bit |IEEE754|_ numbers, or different widths of packed integer values specifically 2 64-bit integers, 4 32-bit integers, 8 16-bit integers, or 16 8-bit integers.
-
-The number of packed values defined here are lanes :`lanes` can be determined by the bit width :math:`N` of the packed value type.
-
-.. math::
-   lanes = 128/N
+Fixed-width SIMD are 128-bit values that are represented in the abstract syntax using |i128|. The interpretation of lane types (integers or floating-point numbers) and lane sizes are determined by the specific instruction operating on them.
 
 .. index:: ! name, byte, Unicode, UTF-8, character, binary format
    pair: abstract syntax; name

--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -19,7 +19,7 @@ Value Types
      \text{i64} &\Rightarrow& \I64 \\ &&|&
      \text{f32} &\Rightarrow& \F32 \\ &&|&
      \text{f64} &\Rightarrow& \F64 \\ &&|&
-     \text{s128} &\Rightarrow& \S128 \\
+     \text{v128} &\Rightarrow& \V128 \\
    \end{array}
 
 

--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -18,7 +18,8 @@ Value Types
      \text{i32} &\Rightarrow& \I32 \\ &&|&
      \text{i64} &\Rightarrow& \I64 \\ &&|&
      \text{f32} &\Rightarrow& \F32 \\ &&|&
-     \text{f64} &\Rightarrow& \F64 \\
+     \text{f64} &\Rightarrow& \F64 \\ &&|&
+     \text{s128} &\Rightarrow& \S128 \\
    \end{array}
 
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -149,13 +149,12 @@
 .. |i16| mathdef:: \xref{syntax/values}{syntax-int}{\X{i16}}
 .. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\X{i32}}
 .. |i64| mathdef:: \xref{syntax/values}{syntax-int}{\X{i64}}
+.. |i128| mathdef:: \xref{syntax/values}{syntax-int}{\X{i128}}
 
 .. |fN| mathdef:: \xref{syntax/values}{syntax-float}{\X{f}N}
 .. |fNmag| mathdef:: \xref{syntax/values}{syntax-float}{\X{f}\X{Nmag}}
 .. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\X{f32}}
 .. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\X{f64}}
-
-.. |s128| mathdef:: \xref{syntax/values}{syntax-simd}{\X{s128}}
 
 .. |name| mathdef:: \xref{syntax/values}{syntax-name}{\X{name}}
 .. |char| mathdef:: \xref{syntax/values}{syntax-name}{\X{char}}
@@ -178,7 +177,7 @@
 .. |I64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i64}}
 .. |F32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f32}}
 .. |F64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f64}}
-.. |S128| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{s128}}
+.. |V128| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{v128}}
 
 .. |FUNCREF| mathdef:: \xref{syntax/types}{syntax-elemtype}{\K{funcref}}
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -155,6 +155,8 @@
 .. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\X{f32}}
 .. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\X{f64}}
 
+.. |s128| mathdef:: \xref{syntax/values}{syntax-simd}{\X{s128}}
+
 .. |name| mathdef:: \xref{syntax/values}{syntax-name}{\X{name}}
 .. |char| mathdef:: \xref{syntax/values}{syntax-name}{\X{char}}
 
@@ -176,6 +178,7 @@
 .. |I64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i64}}
 .. |F32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f32}}
 .. |F64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f64}}
+.. |S128| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{s128}}
 
 .. |FUNCREF| mathdef:: \xref{syntax/types}{syntax-elemtype}{\K{funcref}}
 


### PR DESCRIPTION
This is meant to replace #193 .
Address the feedback given there:

- Issue with using the term "packed integers" in defining the value of 128-bit SIMD. Use i128 instead. Later on, when introducing SIMD instructions, we can add pseudo instructions to convert i128 into the expected lane shapes
- use v128 instead of s128, v128 is used in multiple places, BinarySIMD.md, SIMD.md, reference interpreter, plus s128 already means signed 128-bit integer.

I cherry-picked Deepti's changes from #193, excluding the merge commits, since this PR is rebased on top of master and so already have those changes. The additions/modifications I made are in the latest two commits:
- 4bd26e3ba9d08b6448e0ecdc5b967a948e31b38e
- 8e1bda60cec910c48e1de09c8ca923380226fc01

Looking at only those two might make the review easier. (using the commit tab in this PR)