### PR TITLE
Add SIMD instructions to syntax

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -210,7 +210,7 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{v128.}\vsunop \\&&|&
      \K{v128.}\vsbinop \\&&|&
      \K{v128.}\vsternop \\&&|&
-     \K{v8x16.}\SHUFFLE~\laneidx^{16} ~|~ \K{v8x16.}\SWIZZLE \\&&|&
+     \K{i8x16.}\SHUFFLE~\laneidx^{16} ~|~ \K{i8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
      \K{i8x16.}\EXTRACTLANE\K{\_}\sx~\laneidx ~|~
      \K{i16x8.}\EXTRACTLANE\K{\_}\sx~\laneidx \\&&|&
@@ -424,10 +424,13 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
      \K{i}\X{nn}\K{.}\STORE\K{8}~\memarg ~|~
      \K{i}\X{nn}\K{.}\STORE\K{16}~\memarg ~|~
      \K{i64.}\STORE\K{32}~\memarg \\&&|&
-     \K{i16x8.}\LOAD\K{8x8}\_\sx~\memarg ~|~
-     \K{i32x4.}\LOAD\K{16x4}\_\sx~\memarg ~|~
-     \K{i64x2.}\LOAD\K{32x2}\_\sx~\memarg \\&&|&
-     \X{vxx}\K{.}\LOAD\K{\_splat}~\memarg \\&&|&
+     \K{v128.}\LOAD\K{8x8}\_\sx~\memarg ~|~
+     \K{v128.}\LOAD\K{16x4}\_\sx~\memarg ~|~
+     \K{v128.}\LOAD\K{32x2}\_\sx~\memarg \\&&|&
+     \K{v128.}\LOAD\K{8\_splat}~\memarg ~|~
+     \K{v128.}\LOAD\K{16\_splat}~\memarg \\&&|&
+     \K{v128.}\LOAD\K{32\_splat}~\memarg ~|~
+     \K{v128.}\LOAD\K{64\_splat}~\memarg \\&&|&
      \MEMORYSIZE \\&&|&
      \MEMORYGROW \\
    \end{array}
@@ -437,7 +440,7 @@ They all take a *memory immediate* |memarg| that contains an address *offset* an
 Integer loads and stores can optionally specify a *storage size* that is smaller than the :ref:`bit width <syntax-valtype>` of the respective value type.
 In the case of loads, a sign extension mode |sx| is then required to select appropriate behavior.
 
-SIMD loads can specify a shape that is half the :ref:`bit width <syntax-valtype>` of |V128|. Each lane is half its usual size, and the sign extension mode |sx| then specifies how the smaller lane is extended to the larger lane. Alternatively, SIMD loads can perform a *splat*, such that only a single lane of the respective shape is loaded, and the result is duplicated to all other lanes.
+SIMD loads can specify a shape that is half the :ref:`bit width <syntax-valtype>` of |V128|. Each lane is half its usual size, and the sign extension mode |sx| then specifies how the smaller lane is extended to the larger lane. Alternatively, SIMD loads can perform a *splat*, such that only a single lane of the specified storage size is loaded, and the result is duplicated to all lanes.
 
 The static address offset is added to the dynamic address operand, yielding a 33 bit *effective address* that is the zero-based index at which the memory is accessed.
 All values are read and written in |LittleEndian|_ byte order.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -437,7 +437,7 @@ They all take a *memory immediate* |memarg| that contains an address *offset* an
 Integer loads and stores can optionally specify a *storage size* that is smaller than the :ref:`bit width <syntax-valtype>` of the respective value type.
 In the case of loads, a sign extension mode |sx| is then required to select appropriate behavior.
 
-SIMD loads can specify a shape that is half the :ref:`bit width <syntax-valtype>` of |V128|. Each lane is half its usual size, and the sign extension mode |sx| then specifies how the smaller lane is extended to the larger lane. SIMD loads can be annotated with *splat*, to indicate that only a single lane of the respective shape is loaded, and the result is duplicated to all other lanes.
+SIMD loads can specify a shape that is half the :ref:`bit width <syntax-valtype>` of |V128|. Each lane is half its usual size, and the sign extension mode |sx| then specifies how the smaller lane is extended to the larger lane. Alternatively, SIMD loads can perform a *splat*, such that only a single lane of the respective shape is loaded, and the result is duplicated to all other lanes.
 
 The static address offset is added to the dynamic address operand, yielding a 33 bit *effective address* that is the zero-based index at which the memory is accessed.
 All values are read and written in |LittleEndian|_ byte order.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -172,6 +172,7 @@ Occasionally, it is convenient to group operators together according to the foll
 
 .. index:: ! simd instruction, fixed-width simd, value, value type
    pair: abstract syntax; instruction
+.. _syntax-laneidx:
 .. _syntax-vunop:
 .. _syntax-vbinop:
 .. _syntax-vsunop:
@@ -202,20 +203,21 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{f32x4} ~|~ \K{f64x2} \\
    \production{vshape} & \X{vxx} &::=&
      \X{ixx} ~|~ \X{fxx} \\
+   \production{lane index} & \laneidx &::=& \byte \\
    \production{instruction} & \instr &::=&
      \dots \\&&|&
      \K{v128.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{nnn}}} \\&&|&
      \K{v128.}\vsunop \\&&|&
      \K{v128.}\vsbinop \\&&|&
      \K{v128.}\vsternop \\&&|&
-     \K{v8x16.}\SHUFFLE ~|~ \K{v8x16.}\SWIZZLE \\&&|&
+     \K{v8x16.}\SHUFFLE~\laneidx^{16} ~|~ \K{v8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
-     \K{i8x16.}\EXTRACTLANE\K{\_}\sx ~|~
-     \K{i16x8.}\EXTRACTLANE\K{\_}\sx \\&&|&
-     \K{i32x4.}\EXTRACTLANE ~|~
-     \K{i64x2.}\EXTRACTLANE \\&&|&
-     \X{fxx}\K{.}\EXTRACTLANE \\&&|&
-     \X{vxx}\K{.}\REPLACELANE \\&&|&
+     \K{i8x16.}\EXTRACTLANE\K{\_}\sx~\laneidx ~|~
+     \K{i16x8.}\EXTRACTLANE\K{\_}\sx~\laneidx \\&&|&
+     \K{i32x4.}\EXTRACTLANE~\laneidx ~|~
+     \K{i64x2.}\EXTRACTLANE~\laneidx \\&&|&
+     \X{fxx}\K{.}\EXTRACTLANE~\laneidx \\&&|&
+     \X{vxx}\K{.}\REPLACELANE~\laneidx \\&&|&
      \X{ixx}\K{.}\virelop \\&&|&
      \X{fxx}\K{.}\vfrelop \\&&|&
      \K{i8x16.}\viunop ~|~

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -208,7 +208,8 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{v128.}\vsunop \\&&|&
      \K{v128.}\vsbinop \\&&|&
      \K{v128.}\vsternop \\&&|&
-     \K{i8x16.}\SHUFFLE~\laneidx^{16} ~|~ \K{i8x16.}\SWIZZLE \\&&|&
+     \K{i8x16.}\SHUFFLE~\laneidx^{16} \\&&|&
+     \K{i8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
      \K{i8x16.}\EXTRACTLANE\K{\_}\sx~\laneidx ~|~
      \K{i16x8.}\EXTRACTLANE\K{\_}\sx~\laneidx \\&&|&
@@ -318,9 +319,6 @@ Operations are performed point-wise on the values of each lane.
    The bitwidth of the numeric type :math:`t` times :math:`N` always is 128.
 
 Instructions prefixed with :math:`\K{v128}` do not involve a specific interpretation, and treat the |V128| as an |i128| value or a vector of 128 individual bits.
-
-.. todo::
-  write up runtime interpretation for the lane shapes
 
 SIMD instructions can be grouped into several subcategories:
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -336,11 +336,11 @@ SIMD instructions can be grouped into several subcategories:
 
 * *Shifts*: consume a |v128| operand and a |i32| operand, producing one |V128| result.
 
-* *Splats*: consume a value of the integer or floating-point type and produce a |V128| result of a specified shape.
+* *Splats*: consume a value of numeric type and produce a |V128| result of a specified shape.
 
-* *Extract lanes*: consume a |V128| operand and an immediate byte specifying the lane index and produce a result of the element type.
+* *Extract lanes*: consume a |V128| operand and return the numeric value in a given lane.
 
-* *Replace lanes*: consume a |V128| operand, an immediate byte specifying the lane index, and a value of the element type, and produce a |V128| result.
+* *Replace lanes*: consume a |V128| operand and a numeric value for a given lane, and produce a |V128| result.
 
 Some SIMD instructions have a signedness annotation |sx| which distinguishes whether the elements in the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
 For the other SIMD instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -181,6 +181,7 @@ Occasionally, it is convenient to group operators together according to the foll
 .. _syntax-vshiftop:
 .. _syntax-viunop:
 .. _syntax-vibinop:
+.. _syntax-viminmaxop:
 .. _syntax-vsatbinop:
 .. _syntax-vfunop:
 .. _syntax-vfbinop:
@@ -235,11 +236,10 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{i16x8.}\WIDEN\K{\_high}\K{\_i8x16\_}\sx ~|~
      \K{i32x4.}\WIDEN\K{\_high}\K{\_i16x8\_}\sx \\&&|&
      \X{ixx}\K{.}\vshiftop \\&&|&
-     \K{i8x16.}\vibinop ~|~
-     \K{i16x8.}\vibinop ~|~
-     \K{i32x4.}\vibinop \\&&|&
-     \K{i64x2.}\ADD ~|~
-     \K{i64x2.}\SUB \\&&|&
+     \X{ixx}\K{.}\vibinop \\&&|&
+     \K{i8x16.}\viminmaxop ~|~
+     \K{i16x8.}\viminmaxop ~|~
+     \K{i32x4.}\viminmaxop \\&&|&
      \K{i8x16.}\vsatbinop ~|~
      \K{i16x8.}\vsatbinop \\&&|&
      \K{i16x8.}\K{mul} ~|~
@@ -286,7 +286,8 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{neg} \\
    \production{SIMD integer binary operator} & \vibinop &::=&
      \K{add} ~|~
-     \K{sub} ~|~
+     \K{sub} \\
+   \production{SIMD integer binary min/max operator} & \viminmaxop &::=&
      \K{min\_}\sx ~|~
      \K{max\_}\sx \\
    \production{SIMD integer saturating binary operator} & \vsatbinop &::=&

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -173,12 +173,12 @@ Occasionally, it is convenient to group operators together according to the foll
 .. index:: ! simd instruction, fixed-width simd, value, value type
    pair: abstract syntax; instruction
 .. _syntax-laneidx:
-.. _syntax-vunop:
-.. _syntax-vbinop:
 .. _syntax-vsunop:
 .. _syntax-vsbinop:
 .. _syntax-vsternop:
 .. _syntax-vtestop:
+.. _syntax-virelop:
+.. _syntax-vfrelop:
 .. _syntax-vshiftop:
 .. _syntax-viunop:
 .. _syntax-vibinop:
@@ -186,8 +186,6 @@ Occasionally, it is convenient to group operators together according to the foll
 .. _syntax-vsatbinop:
 .. _syntax-vfunop:
 .. _syntax-vfbinop:
-.. _syntax-virelop:
-.. _syntax-vfrelop:
 .. _syntax-instr-simd:
 
 SIMD Instructions

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -189,7 +189,7 @@ Occasionally, it is convenient to group operators together according to the foll
 .. _syntax-instr-simd:
 
 SIMD Instructions
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 SIMD instructions provide basic operations over :ref:`values <syntax-value>` of type |V128|.
 
@@ -201,9 +201,8 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{f32x4} ~|~ \K{f64x2} \\
    \production{vshape} & \X{vxx} &::=&
      \X{ixx} ~|~ \X{fxx} \\
-   \production{signedness} & \sx &::=&
-     \K{u} ~|~ \K{s} \\
    \production{instruction} & \instr &::=&
+     \dots \\&&|&
      \K{v128.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{nnn}}} \\&&|&
      \K{v128.}\vsunop \\&&|&
      \K{v128.}\vsbinop \\&&|&

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -324,6 +324,8 @@ SIMD instructions can be grouped into several subcategories:
 
 * *Binary Operations*: consume two |V128| operands and produce one |V128| result.
 
+* *Ternary Operations*: consume three |V128| operands and produce one |V128| result.
+
 * *Tests*: consume one |V128| operand and produce a Boolean integer result.
 
 * *Shifts*: consume a |v128| operand and a |i32| operand, producing one |V128| result.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -35,16 +35,6 @@ The following sections group instructions into a number of different categories.
 .. _syntax-fbinop:
 .. _syntax-ftestop:
 .. _syntax-frelop:
-.. _syntax-vunop:
-.. _syntax-vbinop:
-.. _syntax-vternop:
-.. _syntax-vtestop:
-.. _syntax-vshiftop:
-.. _syntax-viunop:
-.. _syntax-vibinop:
-.. _syntax-vsatbinop:
-.. _syntax-vfunop:
-.. _syntax-vfbinop:
 .. _syntax-instr-numeric:
 
 Numeric Instructions
@@ -53,31 +43,22 @@ Numeric Instructions
 Numeric instructions provide basic operations over numeric :ref:`values <syntax-value>` of specific :ref:`type <syntax-valtype>`.
 These operations closely match respective operations available in hardware.
 
+.. todo::
+   add a note about how 128-bit SIMD instructions are different from numeric instructions and are described in the section below.
+
 .. math::
    \begin{array}{llcl}
    \production{width} & \X{nn}, \X{mm} &::=&
      \K{32} ~|~ \K{64} \\
-   \production{simdwidth} & \X{sss} &::=&
-     \K{128} \\
    \production{signedness} & \sx &::=&
      \K{u} ~|~ \K{s} \\
-   \production{ishape} & \X{ixx} &::=&
-     \K{i8x16} ~|~ \K{i16x8} ~|~ \K{i32x4} ~|~ \K{i64x2} \\
-   \production{fshape} & \X{fxx} &::=&
-     \K{f32x4} ~|~ \K{f64x2} \\
-   \production{vshape} & \X{vxx} &::=&
-     \X{ixx} ~|~ \X{fxx} \\
    \production{instruction} & \instr &::=&
      \K{i}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-int}{\iX{\X{nn}}} ~|~
-     \K{f}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} ~|~
-     \K{v}\X{sss}\K{.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{sss}}} \\&&|&
+     \K{f}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} \\&&|&
      \K{i}\X{nn}\K{.}\iunop ~|~
-     \K{f}\X{nn}\K{.}\funop ~|~
-     \K{v}\X{sss}\K{.}\vunop \\&&|&
+     \K{f}\X{nn}\K{.}\funop \\&&|&
      \K{i}\X{nn}\K{.}\ibinop ~|~
-     \K{f}\X{nn}\K{.}\fbinop ~|~
-     \K{v}\X{sss}\K{.}\vbinop \\&&|&
-     \K{v}\X{sss}\K{.}\vternop \\&&|&
+     \K{f}\X{nn}\K{.}\fbinop \\&&|&
      \K{i}\X{nn}\K{.}\itestop \\&&|&
      \K{i}\X{nn}\K{.}\irelop ~|~
      \K{f}\X{nn}\K{.}\frelop \\&&|&
@@ -93,6 +74,153 @@ These operations closely match respective operations available in hardware.
      \K{f}\X{nn}\K{.}\CONVERT\K{\_i}\X{mm}\K{\_}\sx \\&&|&
      \K{i}\X{nn}\K{.}\REINTERPRET\K{\_f}\X{nn} ~|~
      \K{f}\X{nn}\K{.}\REINTERPRET\K{\_i}\X{nn} \\&&|&
+     \dots \\
+   \production{integer unary operator} & \iunop &::=&
+     \K{clz} ~|~
+     \K{ctz} ~|~
+     \K{popcnt} \\
+   \production{integer binary operator} & \ibinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{mul} ~|~
+     \K{div\_}\sx ~|~
+     \K{rem\_}\sx \\&&|&
+     \K{and} ~|~
+     \K{or} ~|~
+     \K{xor} ~|~
+     \K{shl} ~|~
+     \K{shr\_}\sx ~|~
+     \K{rotl} ~|~
+     \K{rotr} \\
+   \production{floating-point unary operator} & \funop &::=&
+     \K{abs} ~|~
+     \K{neg} ~|~
+     \K{sqrt} ~|~
+     \K{ceil} ~|~ 
+     \K{floor} ~|~ 
+     \K{trunc} ~|~ 
+     \K{nearest} \\
+   \production{floating-point binary operator} & \fbinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{mul} ~|~
+     \K{div} ~|~
+     \K{min} ~|~
+     \K{max} ~|~
+     \K{copysign} \\
+   \production{integer test operator} & \itestop &::=&
+     \K{eqz} \\
+   \production{integer relational operator} & \irelop &::=&
+     \K{eq} ~|~
+     \K{ne} ~|~
+     \K{lt\_}\sx ~|~
+     \K{gt\_}\sx ~|~
+     \K{le\_}\sx ~|~
+     \K{ge\_}\sx \\
+   \production{floating-point relational operator} & \frelop &::=&
+     \K{eq} ~|~
+     \K{ne} ~|~
+     \K{lt} ~|~
+     \K{gt} ~|~
+     \K{le} ~|~
+     \K{ge} \\
+   \end{array}
+
+Numeric instructions are divided by :ref:`value type <syntax-valtype>`.
+For each type, several subcategories can be distinguished:
+
+* *Constants*: return a static constant.
+
+* *Unary Operations*: consume one operand and produce one result of the respective type.
+
+* *Binary Operations*: consume two operands and produce one result of the respective type.
+
+* *Tests*: consume one operand of the respective type and produce a Boolean integer result.
+
+* *Comparisons*: consume two operands of the respective type and produce a Boolean integer result.
+
+* *Conversions*: consume a value of one type and produce a result of another
+  (the source type of the conversion is the one after the ":math:`\K{\_}`").
+
+.. todo::
+  Do these subcategories have to cover every instruction? E.g. simd shifts don't fit anywhere here, since they take 128-bit int and a 32-bit int.
+
+Some integer instructions come in two flavors,
+where a signedness annotation |sx| distinguishes whether the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
+For the other integer instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
+
+Instructions that operate on |V128| operands have a naming convention that
+determines how those operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
+will interpret its operands as four |i32|, packed side-by-side into a |i128|.
+Similarly, and instruction beginning with :math:`\K{f64x2}` interprets its operands as two |f64|, packed side-by-side into a |i128|.
+
+.. todo::
+  write up runtime interpretation for the lane shapes
+
+Conventions
+...........
+
+Occasionally, it is convenient to group operators together according to the following grammar shorthands:
+
+.. math::
+   \begin{array}{llll}
+   \production{unary operator} & \unop &::=&
+     \iunop ~|~
+     \funop ~|~
+     \EXTEND{N}\K{\_s} \\
+   \production{binary operator} & \binop &::=& \ibinop ~|~ \fbinop \\
+   \production{test operator} & \testop &::=& \itestop \\
+   \production{relational operator} & \relop &::=& \irelop ~|~ \frelop \\
+   \production{conversion operator} & \cvtop &::=&
+     \WRAP ~|~
+     \EXTEND ~|~
+     \TRUNC ~|~
+     \TRUNC\K{\_sat} ~|~
+     \CONVERT ~|~
+     \DEMOTE ~|~
+     \PROMOTE ~|~
+     \REINTERPRET \\
+   \end{array}
+
+
+.. index:: ! parametric instruction, value type
+   pair: abstract syntax; instruction
+.. _syntax-instr-parametric:
+
+.. index:: ! simd instruction, fixed-width simd, value, value type
+   pair: abstract syntax; instruction
+.. _syntax-vunop:
+.. _syntax-vbinop:
+.. _syntax-vternop:
+.. _syntax-vtestop:
+.. _syntax-vshiftop:
+.. _syntax-viunop:
+.. _syntax-vibinop:
+.. _syntax-vsatbinop:
+.. _syntax-vfunop:
+.. _syntax-vfbinop:
+.. _syntax-instr-simd:
+
+SIMD Instructions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. math::
+   \begin{array}{llcl}
+   \production{simdwidth} & \X{sss} &::=&
+     \K{128} \\
+   \production{signedness} & \sx &::=&
+     \K{u} ~|~ \K{s} \\
+   \production{ishape} & \X{ixx} &::=&
+     \K{i8x16} ~|~ \K{i16x8} ~|~ \K{i32x4} ~|~ \K{i64x2} \\
+   \production{fshape} & \X{fxx} &::=&
+     \K{f32x4} ~|~ \K{f64x2} \\
+   \production{vshape} & \X{vxx} &::=&
+     \X{ixx} ~|~ \X{fxx} \\
+   \production{instruction} & \instr &::=&
+     \K{v}\X{sss}\K{.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{sss}}} \\&&|&
+     \K{v}\X{sss}\K{.}\vunop \\&&|&
+     \K{v}\X{sss}\K{.}\vbinop \\&&|&
+     \K{v}\X{sss}\K{.}\vternop \\&&|&
      \K{v8x16.}\SHUFFLE ~|~ \K{v8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
      \K{i8x16.}\EXTRACTLANE\K{\_}\sx ~|~
@@ -137,39 +265,6 @@ These operations closely match respective operations available in hardware.
      \K{i32x4.}\TRUNC\K{\_sat\_f32x4\_}\sx ~|~
      \K{f32x4.}\CONVERT\K{\_i32x4\_}\sx \\&&|&
      \dots \\
-   \production{integer unary operator} & \iunop &::=&
-     \K{clz} ~|~
-     \K{ctz} ~|~
-     \K{popcnt} \\
-   \production{integer binary operator} & \ibinop &::=&
-     \K{add} ~|~
-     \K{sub} ~|~
-     \K{mul} ~|~
-     \K{div\_}\sx ~|~
-     \K{rem\_}\sx \\&&|&
-     \K{and} ~|~
-     \K{or} ~|~
-     \K{xor} ~|~
-     \K{shl} ~|~
-     \K{shr\_}\sx ~|~
-     \K{rotl} ~|~
-     \K{rotr} \\
-   \production{floating-point unary operator} & \funop &::=&
-     \K{abs} ~|~
-     \K{neg} ~|~
-     \K{sqrt} ~|~
-     \K{ceil} ~|~ 
-     \K{floor} ~|~ 
-     \K{trunc} ~|~ 
-     \K{nearest} \\
-   \production{floating-point binary operator} & \fbinop &::=&
-     \K{add} ~|~
-     \K{sub} ~|~
-     \K{mul} ~|~
-     \K{div} ~|~
-     \K{min} ~|~
-     \K{max} ~|~
-     \K{copysign} \\
    \production{SIMD unary operator} & \vunop &::=&
      \K{not} \\
    \production{SIMD binary operator} & \vbinop &::=&
@@ -226,80 +321,9 @@ These operations closely match respective operations available in hardware.
      \K{max} \\
    \end{array}
 
-Numeric instructions are divided by :ref:`value type <syntax-valtype>`.
-For each type, several subcategories can be distinguished:
-
-* *Constants*: return a static constant.
-
-* *Unary Operations*: consume one operand and produce one result of the respective type.
-
-* *Binary Operations*: consume two operands and produce one result of the respective type.
-
-* *Tests*: consume one operand of the respective type and produce a Boolean integer result.
-
-* *Comparisons*: consume two operands of the respective type and produce a Boolean integer result or a result of the respective type.
-
-* *Conversions*: consume a value of one type and produce a result of another
-  (the source type of the conversion is the one after the ":math:`\K{\_}`").
 
 .. todo::
-  Do these subcategories have to cover every instruction? E.g. simd shifts don't fit anywhere here, since they take 128-bit int and a 32-bit int.
-
-Some integer instructions come in two flavors,
-where a signedness annotation |sx| distinguishes whether the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
-For the other integer instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
-
-Instructions that operate on |V128| operands have a naming convention that
-determines how those operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
-will interpret its operands as four |i32|, packed side-by-side into a |i128|.
-Similarly, and instruction beginning with :math:`\K{f64x2}` interprets its operands as two |f64|, packed side-by-side into a |i128|.
-
-.. todo::
-  write up runtime interpretation for the lane shapes
-
-Conventions
-...........
-
-Occasionally, it is convenient to group operators together according to the following grammar shorthands:
-
-.. math::
-   \begin{array}{llll}
-   \production{unary operator} & \unop &::=&
-     \iunop ~|~
-     \funop ~|~
-     \vunop ~|~
-     \viunop ~|~
-     \vfunop ~|~
-     \EXTEND{N}\K{\_s} \\
-   \production{binary operator} & \binop &::=&
-     \ibinop ~|~
-     \fbinop ~|~
-     \vbinop ~|~
-     \vibinop ~|~
-     \vsatbinop ~|~
-     \vfbinop ~|~
-     \AVGRU \\
-   \production{test operator} & \testop &::=&
-     \itestop ~|~
-     \vtestop \\
-   \production{relational operator} & \relop &::=& \irelop ~|~ \frelop \\
-   \production{conversion operator} & \cvtop &::=&
-     \WRAP ~|~
-     \EXTEND ~|~
-     \TRUNC ~|~
-     \TRUNC\K{\_sat} ~|~
-     \CONVERT ~|~
-     \DEMOTE ~|~
-     \PROMOTE ~|~
-     \REINTERPRET ~|~
-     \NARROW ~|~
-     \WIDEN \\
-   \end{array}
-
-
-.. index:: ! parametric instruction, value type
-   pair: abstract syntax; instruction
-.. _syntax-instr-parametric:
+   describe SIMD Instructions
 
 Parametric Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -436,6 +436,8 @@ They all take a *memory immediate* |memarg| that contains an address *offset* an
 Integer loads and stores can optionally specify a *storage size* that is smaller than the :ref:`bit width <syntax-valtype>` of the respective value type.
 In the case of loads, a sign extension mode |sx| is then required to select appropriate behavior.
 
+SIMD loads can specify a shape that is half the :ref:`bit width <syntax-valtype>` of |V128|. Each lane is half its usual size, and the sign extension mode |sx| then specifies how the smaller lane is extended to the larger lane. SIMD loads can be annotated with *splat*, to indicate that only a single lane of the respective shape is loaded, and the result is duplicated to all other lanes.
+
 The static address offset is added to the dynamic address operand, yielding a 33 bit *effective address* that is the zero-based index at which the memory is accessed.
 All values are read and written in |LittleEndian|_ byte order.
 A :ref:`trap <trap>` results if any of the accessed memory bytes lies outside the address range implied by the memory's current size.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -206,8 +206,6 @@ SIMD Instructions
 
 .. math::
    \begin{array}{llcl}
-   \production{simdwidth} & \X{sss} &::=&
-     \K{128} \\
    \production{signedness} & \sx &::=&
      \K{u} ~|~ \K{s} \\
    \production{ishape} & \X{ixx} &::=&
@@ -217,10 +215,10 @@ SIMD Instructions
    \production{vshape} & \X{vxx} &::=&
      \X{ixx} ~|~ \X{fxx} \\
    \production{instruction} & \instr &::=&
-     \K{v}\X{sss}\K{.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{sss}}} \\&&|&
-     \K{v}\X{sss}\K{.}\vunop \\&&|&
-     \K{v}\X{sss}\K{.}\vbinop \\&&|&
-     \K{v}\X{sss}\K{.}\vternop \\&&|&
+     \K{v128.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{nnn}}} \\&&|&
+     \K{v128.}\vunop \\&&|&
+     \K{v128.}\vbinop \\&&|&
+     \K{v128.}\vternop \\&&|&
      \K{v8x16.}\SHUFFLE ~|~ \K{v8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
      \K{i8x16.}\EXTRACTLANE\K{\_}\sx ~|~
@@ -274,8 +272,6 @@ SIMD Instructions
      \K{xor} \\
    \production{SIMD ternary operator} & \vternop &::=&
      \K{bitselect} \\
-   \production{integer test operator} & \itestop &::=&
-     \K{eqz} \\
    \production{SIMD test operator} & \vtestop &::=&
      \K{any\_true} ~|~
      \K{all\_true} \\
@@ -387,10 +383,10 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
      \dots \\&&|&
      \K{i}\X{nn}\K{.}\LOAD~\memarg ~|~
      \K{f}\X{nn}\K{.}\LOAD~\memarg ~|~
-     \K{v}\X{sss}\K{.}\LOAD~\memarg \\&&|&
+     \K{v128.}\LOAD~\memarg \\&&|&
      \K{i}\X{nn}\K{.}\STORE~\memarg ~|~
      \K{f}\X{nn}\K{.}\STORE~\memarg ~|~
-     \K{v}\X{sss}\K{.}\STORE~\memarg \\&&|&
+     \K{v128.}\STORE~\memarg \\&&|&
      \K{i}\X{nn}\K{.}\LOAD\K{8\_}\sx~\memarg ~|~
      \K{i}\X{nn}\K{.}\LOAD\K{16\_}\sx~\memarg ~|~
      \K{i64.}\LOAD\K{32\_}\sx~\memarg \\&&|&
@@ -400,7 +396,7 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
      \K{i16x8.}\LOAD\K{8x8}\_\sx ~|~
      \K{i32x4.}\LOAD\K{16x4}\_\sx ~|~
      \K{i64x2.}\LOAD\K{32x2}\_\sx \\&&|&
-     \K{v}\X{ixx}\K{.}\LOAD\K{\_splat} \\&&|&
+     \K{v128.}\LOAD\K{\_splat} \\&&|&
      \MEMORYSIZE \\&&|&
      \MEMORYGROW \\
    \end{array}

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -177,7 +177,7 @@ These operations closely match respective operations available in hardware.
      \K{andnot} ~|~
      \K{or} ~|~
      \K{xor} \\
-   \production{SIMD unary operator} & \vternop &::=&
+   \production{SIMD ternary operator} & \vternop &::=&
      \K{bitselect} \\
    \production{integer test operator} & \itestop &::=&
      \K{eqz} \\
@@ -272,17 +272,16 @@ Occasionally, it is convenient to group operators together according to the foll
      \vfunop ~|~
      \EXTEND{N}\K{\_s} \\
    \production{binary operator} & \binop &::=&
-   \ibinop ~|~
-   \fbinop ~|~
-   \vbinop ~|~
-   \vibinop ~|~
-   \vsatbinop ~|~
-   \vfbinop ~|~
-   \AVGRU
-   \\
+     \ibinop ~|~
+     \fbinop ~|~
+     \vbinop ~|~
+     \vibinop ~|~
+     \vsatbinop ~|~
+     \vfbinop ~|~
+     \AVGRU \\
    \production{test operator} & \testop &::=&
-   \itestop ~|~
-   \vtestop \\
+     \itestop ~|~
+     \vtestop \\
    \production{relational operator} & \relop &::=& \irelop ~|~ \frelop \\
    \production{conversion operator} & \cvtop &::=&
      \WRAP ~|~

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -314,7 +314,7 @@ Operations are performed point-wise on the values of each lane.
 
 .. note::
    For example, the shape :math:`\K{i32x4}` interprets the operand
-as four |i32| values, packed into an |i128|.
+   as four |i32| values, packed into an |i128|.
    The bitwidth of the numeric type :math:`t` times :math:`N` always is 128.
 
 Instructions prefixed with :math:`\K{v128}` do not involve a specific interpretation, and treat the |V128| as an |i128| value or a vector of 128 individual bits.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -330,18 +330,11 @@ SIMD instructions can be grouped into several subcategories:
 
 * *Shifts*: consume a |v128| operand and a |i32| operand, producing one |V128| result.
 
+* *Splats*: consume a value of the integer or floating-point type and produce a |V128| result of a specified shape.
+
 * *Extract lanes*: consume a |V128| operand and an immediate byte specifying the lane index and produce a result of the element type.
 
 * *Replace lanes*: consume a |V128| operand, an immediate byte specifying the lane index, and a value of the element type, and produce a |V128| result.
-
-* *Conversions/Splats*: consume a value of the integer or floating-point type and produce a |V128| result of a specified shape.
-
-.. todo::
-   should comparisons be called out in a separate subcategory? they are essentially the same as binary operations
-   should (v128) converions be called out in a separate subcategory? they have the same signature as unary opreations.
-
-.. * *Conversions*: consume a |V128| operand and produce a |V128| result. Lane-wise conversion from the source element type to the destination element type (the source type of the conversion is the one after the first ":math:`\K{\_}`").
-
 
 Some SIMD instructions have a signedness annotation |sx| which distinguishes whether the elements in the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
 For the other SIMD instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -43,9 +43,6 @@ Numeric Instructions
 Numeric instructions provide basic operations over numeric :ref:`values <syntax-value>` of specific :ref:`type <syntax-valtype>`.
 These operations closely match respective operations available in hardware.
 
-.. todo::
-   add a note about how 128-bit SIMD instructions are different from numeric instructions and are described in the section below.
-
 .. math::
    \begin{array}{llcl}
    \production{width} & \X{nn}, \X{mm} &::=&
@@ -142,20 +139,10 @@ For each type, several subcategories can be distinguished:
 * *Conversions*: consume a value of one type and produce a result of another
   (the source type of the conversion is the one after the ":math:`\K{\_}`").
 
-.. todo::
-  Do these subcategories have to cover every instruction? E.g. simd shifts don't fit anywhere here, since they take 128-bit int and a 32-bit int.
-
 Some integer instructions come in two flavors,
 where a signedness annotation |sx| distinguishes whether the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
 For the other integer instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
 
-Instructions that operate on |V128| operands have a naming convention that
-determines how those operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
-will interpret its operands as four |i32|, packed side-by-side into a |i128|.
-Similarly, and instruction beginning with :math:`\K{f64x2}` interprets its operands as two |f64|, packed side-by-side into a |i128|.
-
-.. todo::
-  write up runtime interpretation for the lane shapes
 
 Conventions
 ...........
@@ -183,15 +170,13 @@ Occasionally, it is convenient to group operators together according to the foll
    \end{array}
 
 
-.. index:: ! parametric instruction, value type
-   pair: abstract syntax; instruction
-.. _syntax-instr-parametric:
-
 .. index:: ! simd instruction, fixed-width simd, value, value type
    pair: abstract syntax; instruction
 .. _syntax-vunop:
 .. _syntax-vbinop:
-.. _syntax-vternop:
+.. _syntax-vsunop:
+.. _syntax-vsbinop:
+.. _syntax-vsternop:
 .. _syntax-vtestop:
 .. _syntax-vshiftop:
 .. _syntax-viunop:
@@ -199,26 +184,30 @@ Occasionally, it is convenient to group operators together according to the foll
 .. _syntax-vsatbinop:
 .. _syntax-vfunop:
 .. _syntax-vfbinop:
+.. _syntax-virelop:
+.. _syntax-vfrelop:
 .. _syntax-instr-simd:
 
 SIMD Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+SIMD instructions provide basic operations over :ref:`values <syntax-value>` of type |V128|.
+
 .. math::
    \begin{array}{llcl}
-   \production{signedness} & \sx &::=&
-     \K{u} ~|~ \K{s} \\
    \production{ishape} & \X{ixx} &::=&
      \K{i8x16} ~|~ \K{i16x8} ~|~ \K{i32x4} ~|~ \K{i64x2} \\
    \production{fshape} & \X{fxx} &::=&
      \K{f32x4} ~|~ \K{f64x2} \\
    \production{vshape} & \X{vxx} &::=&
      \X{ixx} ~|~ \X{fxx} \\
+   \production{signedness} & \sx &::=&
+     \K{u} ~|~ \K{s} \\
    \production{instruction} & \instr &::=&
      \K{v128.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{nnn}}} \\&&|&
-     \K{v128.}\vunop \\&&|&
-     \K{v128.}\vbinop \\&&|&
-     \K{v128.}\vternop \\&&|&
+     \K{v128.}\vsunop \\&&|&
+     \K{v128.}\vsbinop \\&&|&
+     \K{v128.}\vsternop \\&&|&
      \K{v8x16.}\SHUFFLE ~|~ \K{v8x16.}\SWIZZLE \\&&|&
      \X{vxx}\K{.}\SPLAT \\&&|&
      \K{i8x16.}\EXTRACTLANE\K{\_}\sx ~|~
@@ -227,8 +216,8 @@ SIMD Instructions
      \K{i64x2.}\EXTRACTLANE \\&&|&
      \X{fxx}\K{.}\EXTRACTLANE \\&&|&
      \X{vxx}\K{.}\REPLACELANE \\&&|&
-     \X{ixx}\K{.}\irelop \\&&|&
-     \X{fxx}\K{.}\frelop \\&&|&
+     \X{ixx}\K{.}\virelop \\&&|&
+     \X{fxx}\K{.}\vfrelop \\&&|&
      \K{i8x16.}\viunop ~|~
      \K{i16x8.}\viunop ~|~
      \K{i32x4.}\viunop \\&&|&
@@ -263,26 +252,26 @@ SIMD Instructions
      \K{i32x4.}\TRUNC\K{\_sat\_f32x4\_}\sx ~|~
      \K{f32x4.}\CONVERT\K{\_i32x4\_}\sx \\&&|&
      \dots \\
-   \production{SIMD unary operator} & \vunop &::=&
+   \production{SIMD unary operator} & \vsunop &::=&
      \K{not} \\
-   \production{SIMD binary operator} & \vbinop &::=&
+   \production{SIMD binary operator} & \vsbinop &::=&
      \K{and} ~|~
      \K{andnot} ~|~
      \K{or} ~|~
      \K{xor} \\
-   \production{SIMD ternary operator} & \vternop &::=&
+   \production{SIMD ternary operator} & \vsternop &::=&
      \K{bitselect} \\
    \production{SIMD test operator} & \vtestop &::=&
      \K{any\_true} ~|~
      \K{all\_true} \\
-   \production{integer relational operator} & \irelop &::=&
+   \production{SIMD integer relational operator} & \virelop &::=&
      \K{eq} ~|~
      \K{ne} ~|~
      \K{lt\_}\sx ~|~
      \K{gt\_}\sx ~|~
      \K{le\_}\sx ~|~
      \K{ge\_}\sx \\
-   \production{floating-point relational operator} & \frelop &::=&
+   \production{SIMD floating-point relational operator} & \vfrelop &::=&
      \K{eq} ~|~
      \K{ne} ~|~
      \K{lt} ~|~
@@ -317,9 +306,48 @@ SIMD Instructions
      \K{max} \\
    \end{array}
 
+SIMD instructions have a naming convention that
+determines how their operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
+will interpret its operands as four |i32|, packed side-by-side into a |i128|.
+This prefix, :math:`\K{i32x4}`, is known as the *shape* of the type, and is made up of the underlying element type, :math:`\K{i32}`, and the number of elements or *lanes*, :math:`\K{4}`. Operations are performed lane-wise on each element.
+
+An instruction that begins with :math:`\K{v128}` is not concerned about the underlying element type, and treats the entire |V128| as a |i128|.
 
 .. todo::
-   describe SIMD Instructions
+  write up runtime interpretation for the lane shapes
+
+SIMD instructions can be grouped into several subcategories:
+
+* *Constants*: return a static constant.
+
+* *Unary Operations*: consume one |V128| operand and produce one |V128| result.
+
+* *Binary Operations*: consume two |V128| operands and produce one |V128| result.
+
+* *Tests*: consume one |V128| operand and produce a Boolean integer result.
+
+* *Shifts*: consume a |v128| operand and a |i32| operand, producing one |V128| result.
+
+* *Extract lanes*: consume a |V128| operand and an immediate byte specifying the lane index and produce a result of the element type.
+
+* *Replace lanes*: consume a |V128| operand, an immediate byte specifying the lane index, and a value of the element type, and produce a |V128| result.
+
+* *Conversions/Splats*: consume a value of the integer or floating-point type and produce a |V128| result of a specified shape.
+
+.. todo::
+   should comparisons be called out in a separate subcategory? they are essentially the same as binary operations
+   should (v128) converions be called out in a separate subcategory? they have the same signature as unary opreations.
+
+.. * *Conversions*: consume a |V128| operand and produce a |V128| result. Lane-wise conversion from the source element type to the destination element type (the source type of the conversion is the one after the first ":math:`\K{\_}`").
+
+
+Some SIMD instructions have a signedness annotation |sx| which distinguishes whether the elements in the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
+For the other SIMD instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
+
+
+.. index:: ! parametric instruction, value type
+   pair: abstract syntax; instruction
+.. _syntax-instr-parametric:
 
 Parametric Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -396,7 +424,7 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
      \K{i16x8.}\LOAD\K{8x8}\_\sx ~|~
      \K{i32x4.}\LOAD\K{16x4}\_\sx ~|~
      \K{i64x2.}\LOAD\K{32x2}\_\sx \\&&|&
-     \K{v128.}\LOAD\K{\_splat} \\&&|&
+     \X{vxx}\K{.}\LOAD\K{\_splat} \\&&|&
      \MEMORYSIZE \\&&|&
      \MEMORYGROW \\
    \end{array}

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -424,10 +424,10 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
      \K{i}\X{nn}\K{.}\STORE\K{8}~\memarg ~|~
      \K{i}\X{nn}\K{.}\STORE\K{16}~\memarg ~|~
      \K{i64.}\STORE\K{32}~\memarg \\&&|&
-     \K{i16x8.}\LOAD\K{8x8}\_\sx ~|~
-     \K{i32x4.}\LOAD\K{16x4}\_\sx ~|~
-     \K{i64x2.}\LOAD\K{32x2}\_\sx \\&&|&
-     \X{vxx}\K{.}\LOAD\K{\_splat} \\&&|&
+     \K{i16x8.}\LOAD\K{8x8}\_\sx~\memarg ~|~
+     \K{i32x4.}\LOAD\K{16x4}\_\sx~\memarg ~|~
+     \K{i64x2.}\LOAD\K{32x2}\_\sx~\memarg \\&&|&
+     \X{vxx}\K{.}\LOAD\K{\_splat}~\memarg \\&&|&
      \MEMORYSIZE \\&&|&
      \MEMORYGROW \\
    \end{array}

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -35,6 +35,16 @@ The following sections group instructions into a number of different categories.
 .. _syntax-fbinop:
 .. _syntax-ftestop:
 .. _syntax-frelop:
+.. _syntax-vunop:
+.. _syntax-vbinop:
+.. _syntax-vternop:
+.. _syntax-vtestop:
+.. _syntax-vshiftop:
+.. _syntax-viunop:
+.. _syntax-vibinop:
+.. _syntax-vsatbinop:
+.. _syntax-vfunop:
+.. _syntax-vfbinop:
 .. _syntax-instr-numeric:
 
 Numeric Instructions
@@ -47,15 +57,27 @@ These operations closely match respective operations available in hardware.
    \begin{array}{llcl}
    \production{width} & \X{nn}, \X{mm} &::=&
      \K{32} ~|~ \K{64} \\
+   \production{simdwidth} & \X{sss} &::=&
+     \K{128} \\
    \production{signedness} & \sx &::=&
      \K{u} ~|~ \K{s} \\
+   \production{ishape} & \X{ixx} &::=&
+     \K{i8x16} ~|~ \K{i16x8} ~|~ \K{i32x4} ~|~ \K{i64x2} \\
+   \production{fshape} & \X{fxx} &::=&
+     \K{f32x4} ~|~ \K{f64x2} \\
+   \production{vshape} & \X{vxx} &::=&
+     \X{ixx} ~|~ \X{fxx} \\
    \production{instruction} & \instr &::=&
      \K{i}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-int}{\iX{\X{nn}}} ~|~
-     \K{f}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} \\&&|&
+     \K{f}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} ~|~
+     \K{v}\X{sss}\K{.}\CONST~\xref{syntax/values}{syntax-simd}{\vX{\X{sss}}} \\&&|&
      \K{i}\X{nn}\K{.}\iunop ~|~
-     \K{f}\X{nn}\K{.}\funop \\&&|&
+     \K{f}\X{nn}\K{.}\funop ~|~
+     \K{v}\X{sss}\K{.}\vunop \\&&|&
      \K{i}\X{nn}\K{.}\ibinop ~|~
-     \K{f}\X{nn}\K{.}\fbinop \\&&|&
+     \K{f}\X{nn}\K{.}\fbinop ~|~
+     \K{v}\X{sss}\K{.}\vbinop \\&&|&
+     \K{v}\X{sss}\K{.}\vternop \\&&|&
      \K{i}\X{nn}\K{.}\itestop \\&&|&
      \K{i}\X{nn}\K{.}\irelop ~|~
      \K{f}\X{nn}\K{.}\frelop \\&&|&
@@ -71,6 +93,49 @@ These operations closely match respective operations available in hardware.
      \K{f}\X{nn}\K{.}\CONVERT\K{\_i}\X{mm}\K{\_}\sx \\&&|&
      \K{i}\X{nn}\K{.}\REINTERPRET\K{\_f}\X{nn} ~|~
      \K{f}\X{nn}\K{.}\REINTERPRET\K{\_i}\X{nn} \\&&|&
+     \K{v8x16.}\SHUFFLE ~|~ \K{v8x16.}\SWIZZLE \\&&|&
+     \X{vxx}\K{.}\SPLAT \\&&|&
+     \K{i8x16.}\EXTRACTLANE\K{\_}\sx ~|~
+     \K{i16x8.}\EXTRACTLANE\K{\_}\sx \\&&|&
+     \K{i32x4.}\EXTRACTLANE ~|~
+     \K{i64x2.}\EXTRACTLANE \\&&|&
+     \X{fxx}\K{.}\EXTRACTLANE \\&&|&
+     \X{vxx}\K{.}\REPLACELANE \\&&|&
+     \X{ixx}\K{.}\irelop \\&&|&
+     \X{fxx}\K{.}\frelop \\&&|&
+     \K{i8x16.}\viunop ~|~
+     \K{i16x8.}\viunop ~|~
+     \K{i32x4.}\viunop \\&&|&
+     \K{i64x2.}\NEG \\&&|&
+     \X{fxx.}\vfunop \\&&|&
+     \K{i8x16.}\vtestop ~|~
+     \K{i16x8.}\vtestop ~|~
+     \K{i32x4.}\vtestop \\&&|&
+     \K{i8x16.}\BITMASK ~|~
+     \K{i16x8.}\BITMASK ~|~
+     \K{i32x4.}\BITMASK \\&&|&
+     \K{i8x16.}\NARROW\K{\_i16x8\_}\sx ~|~
+     \K{i16x8.}\NARROW\K{\_i32x4\_}\sx \\&&|&
+     \K{i16x8.}\WIDEN\K{\_low}\K{\_i8x16\_}\sx ~|~
+     \K{i32x4.}\WIDEN\K{\_low}\K{\_i16x8\_}\sx \\&&|&
+     \K{i16x8.}\WIDEN\K{\_high}\K{\_i8x16\_}\sx ~|~
+     \K{i32x4.}\WIDEN\K{\_high}\K{\_i16x8\_}\sx \\&&|&
+     \X{ixx}\K{.}\vshiftop \\&&|&
+     \K{i8x16.}\vibinop ~|~
+     \K{i16x8.}\vibinop ~|~
+     \K{i32x4.}\vibinop \\&&|&
+     \K{i64x2.}\ADD ~|~
+     \K{i64x2.}\SUB \\&&|&
+     \K{i8x16.}\vsatbinop ~|~
+     \K{i16x8.}\vsatbinop \\&&|&
+     \K{i16x8.}\K{mul} ~|~
+     \K{i32x4.}\K{mul} ~|~
+     \K{i64x2.}\K{mul} \\&&|&
+     \K{i8x16.}\AVGRU ~|~
+     \K{i16x8.}\AVGRU \\&&|&
+     \X{fxx.}\vfbinop \\&&|&
+     \K{i32x4.}\TRUNC\K{\_sat\_f32x4\_}\sx ~|~
+     \K{f32x4.}\CONVERT\K{\_i32x4\_}\sx \\&&|&
      \dots \\
    \production{integer unary operator} & \iunop &::=&
      \K{clz} ~|~
@@ -105,8 +170,20 @@ These operations closely match respective operations available in hardware.
      \K{min} ~|~
      \K{max} ~|~
      \K{copysign} \\
+   \production{SIMD unary operator} & \vunop &::=&
+     \K{not} \\
+   \production{SIMD binary operator} & \vbinop &::=&
+     \K{and} ~|~
+     \K{andnot} ~|~
+     \K{or} ~|~
+     \K{xor} \\
+   \production{SIMD unary operator} & \vternop &::=&
+     \K{bitselect} \\
    \production{integer test operator} & \itestop &::=&
      \K{eqz} \\
+   \production{SIMD test operator} & \vtestop &::=&
+     \K{any\_true} ~|~
+     \K{all\_true} \\
    \production{integer relational operator} & \irelop &::=&
      \K{eq} ~|~
      \K{ne} ~|~
@@ -121,6 +198,32 @@ These operations closely match respective operations available in hardware.
      \K{gt} ~|~
      \K{le} ~|~
      \K{ge} \\
+   \production{SIMD integer shift operator} & \vshiftop &::=&
+     \K{shl} ~|~
+     \K{shr\_s} ~|~
+     \K{shr\_u} \\
+   \production{SIMD integer unary operator} & \viunop &::=&
+     \K{abs} ~|~
+     \K{neg} \\
+   \production{SIMD integer binary operator} & \vibinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{min\_}\sx ~|~
+     \K{max\_}\sx \\
+   \production{SIMD integer saturating binary operator} & \vsatbinop &::=&
+     \K{add\_sat\_}\sx ~|~
+     \K{sub\_sat\_}\sx \\
+   \production{SIMD floating-point unary operator} & \vfunop &::=&
+     \K{abs} ~|~
+     \K{neg} ~|~
+     \K{sqrt} \\
+   \production{SIMD floating-point binary operator} & \vfbinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{mul} ~|~
+     \K{div} ~|~
+     \K{min} ~|~
+     \K{max} \\
    \end{array}
 
 Numeric instructions are divided by :ref:`value type <syntax-valtype>`.
@@ -134,15 +237,25 @@ For each type, several subcategories can be distinguished:
 
 * *Tests*: consume one operand of the respective type and produce a Boolean integer result.
 
-* *Comparisons*: consume two operands of the respective type and produce a Boolean integer result.
+* *Comparisons*: consume two operands of the respective type and produce a Boolean integer result or a result of the respective type.
 
 * *Conversions*: consume a value of one type and produce a result of another
   (the source type of the conversion is the one after the ":math:`\K{\_}`").
+
+.. todo::
+  Do these subcategories have to cover every instruction? E.g. simd shifts don't fit anywhere here, since they take 128-bit int and a 32-bit int.
 
 Some integer instructions come in two flavors,
 where a signedness annotation |sx| distinguishes whether the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
 For the other integer instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
 
+Instructions that operate on |V128| operands have a naming convention that
+determines how those operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
+will interpret its operands as four |i32|, packed side-by-side into a |i128|.
+Similarly, and instruction beginning with :math:`\K{f64x2}` interprets its operands as two |f64|, packed side-by-side into a |i128|.
+
+.. todo::
+  write up runtime interpretation for the lane shapes
 
 Conventions
 ...........
@@ -154,9 +267,22 @@ Occasionally, it is convenient to group operators together according to the foll
    \production{unary operator} & \unop &::=&
      \iunop ~|~
      \funop ~|~
+     \vunop ~|~
+     \viunop ~|~
+     \vfunop ~|~
      \EXTEND{N}\K{\_s} \\
-   \production{binary operator} & \binop &::=& \ibinop ~|~ \fbinop \\
-   \production{test operator} & \testop &::=& \itestop \\
+   \production{binary operator} & \binop &::=&
+   \ibinop ~|~
+   \fbinop ~|~
+   \vbinop ~|~
+   \vibinop ~|~
+   \vsatbinop ~|~
+   \vfbinop ~|~
+   \AVGRU
+   \\
+   \production{test operator} & \testop &::=&
+   \itestop ~|~
+   \vtestop \\
    \production{relational operator} & \relop &::=& \irelop ~|~ \frelop \\
    \production{conversion operator} & \cvtop &::=&
      \WRAP ~|~
@@ -166,7 +292,9 @@ Occasionally, it is convenient to group operators together according to the foll
      \CONVERT ~|~
      \DEMOTE ~|~
      \PROMOTE ~|~
-     \REINTERPRET \\
+     \REINTERPRET ~|~
+     \NARROW ~|~
+     \WIDEN \\
    \end{array}
 
 
@@ -235,15 +363,21 @@ Instructions in this group are concerned with linear :ref:`memory <syntax-mem>`.
    \production{instruction} & \instr &::=&
      \dots \\&&|&
      \K{i}\X{nn}\K{.}\LOAD~\memarg ~|~
-     \K{f}\X{nn}\K{.}\LOAD~\memarg \\&&|&
+     \K{f}\X{nn}\K{.}\LOAD~\memarg ~|~
+     \K{v}\X{sss}\K{.}\LOAD~\memarg \\&&|&
      \K{i}\X{nn}\K{.}\STORE~\memarg ~|~
-     \K{f}\X{nn}\K{.}\STORE~\memarg \\&&|&
+     \K{f}\X{nn}\K{.}\STORE~\memarg ~|~
+     \K{v}\X{sss}\K{.}\STORE~\memarg \\&&|&
      \K{i}\X{nn}\K{.}\LOAD\K{8\_}\sx~\memarg ~|~
      \K{i}\X{nn}\K{.}\LOAD\K{16\_}\sx~\memarg ~|~
      \K{i64.}\LOAD\K{32\_}\sx~\memarg \\&&|&
      \K{i}\X{nn}\K{.}\STORE\K{8}~\memarg ~|~
      \K{i}\X{nn}\K{.}\STORE\K{16}~\memarg ~|~
      \K{i64.}\STORE\K{32}~\memarg \\&&|&
+     \K{i16x8.}\LOAD\K{8x8}\_\sx ~|~
+     \K{i32x4.}\LOAD\K{16x4}\_\sx ~|~
+     \K{i64x2.}\LOAD\K{32x2}\_\sx \\&&|&
+     \K{v}\X{ixx}\K{.}\LOAD\K{\_splat} \\&&|&
      \MEMORYSIZE \\&&|&
      \MEMORYGROW \\
    \end{array}

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -306,10 +306,16 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{max} \\
    \end{array}
 
-SIMD instructions have a naming convention that
-determines how their operands will be interpreted. An instruction beginning with :math:`\K{i32x4}`
-will interpret its operands as four |i32|, packed side-by-side into a |i128|.
-This prefix, :math:`\K{i32x4}`, is known as the *shape* of the type, and is made up of the underlying element type, :math:`\K{i32}`, and the number of elements or *lanes*, :math:`\K{4}`. Operations are performed lane-wise on each element.
+SIMD instructions have a naming convention involving a prefix that
+determines how their operands will be interpreted.
+This prefix describes the *shape* of the operand,
+written :math:`t\K{x}N`, and consisting of a packed numeric type :math:`t` and the number of *lanes* :math:`N` of that type.
+Operations are performed point-wise on the values of each lane.
+
+.. note::
+   For example, the shape :math:`\K{i32x4}` interprets the operand
+as four |i32| values, packed into an |i128|.
+   The bitwidth of the numeric type :math:`t` times :math:`N` always is 128.
 
 An instruction that begins with :math:`\K{v128}` is not concerned about the underlying element type, and treats the entire |V128| as a |i128|.
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -317,7 +317,7 @@ Operations are performed point-wise on the values of each lane.
 as four |i32| values, packed into an |i128|.
    The bitwidth of the numeric type :math:`t` times :math:`N` always is 128.
 
-An instruction that begins with :math:`\K{v128}` is not concerned about the underlying element type, and treats the entire |V128| as a |i128|.
+Instructions prefixed with :math:`\K{v128}` do not involve a specific interpretation, and treat the |V128| as an |i128| value or a vector of 128 individual bits.
 
 .. todo::
   write up runtime interpretation for the lane shapes

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -417,6 +417,7 @@
 .. |vshiftop| mathdef:: \xref{syntax/instructions}{syntax-vshiftop}{\X{vshiftop}}
 .. |viunop| mathdef:: \xref{syntax/instructions}{syntax-viunop}{\X{viunop}}
 .. |vibinop| mathdef:: \xref{syntax/instructions}{syntax-vibinop}{\X{vibinop}}
+.. |viminmaxop| mathdef:: \xref{syntax/instructions}{syntax-viminmaxop}{\X{viminmaxop}}
 .. |vsatbinop| mathdef:: \xref{syntax/instructions}{syntax-vsatbinop}{\X{vsatbinop}}
 .. |vfunop| mathdef:: \xref{syntax/instructions}{syntax-vfunop}{\X{vfunop}}
 .. |vfbinop| mathdef:: \xref{syntax/instructions}{syntax-vfbinop}{\X{vfbinop}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -410,7 +410,9 @@
 
 .. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
 .. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
-.. |vternop| mathdef:: \xref{syntax/instructions}{syntax-vternop}{\X{vternop}}
+.. |vsunop| mathdef:: \xref{syntax/instructions}{syntax-vsunop}{\X{vsunop}}
+.. |vsbinop| mathdef:: \xref{syntax/instructions}{syntax-vsbinop}{\X{vsbinop}}
+.. |vsternop| mathdef:: \xref{syntax/instructions}{syntax-vsternop}{\X{vsternop}}
 .. |vtestop| mathdef:: \xref{syntax/instructions}{syntax-vtestop}{\X{vtestop}}
 .. |vshiftop| mathdef:: \xref{syntax/instructions}{syntax-vshiftop}{\X{vshiftop}}
 .. |viunop| mathdef:: \xref{syntax/instructions}{syntax-viunop}{\X{viunop}}
@@ -418,6 +420,8 @@
 .. |vsatbinop| mathdef:: \xref{syntax/instructions}{syntax-vsatbinop}{\X{vsatbinop}}
 .. |vfunop| mathdef:: \xref{syntax/instructions}{syntax-vfunop}{\X{vfunop}}
 .. |vfbinop| mathdef:: \xref{syntax/instructions}{syntax-vfbinop}{\X{vfbinop}}
+.. |virelop| mathdef:: \xref{syntax/instructions}{syntax-virelop}{\X{virelop}}
+.. |vfrelop| mathdef:: \xref{syntax/instructions}{syntax-vfrelop}{\X{vfrelop}}
 
 .. |sx| mathdef:: \xref{syntax/instructions}{syntax-sx}{\X{sx}}
 .. |memarg| mathdef:: \xref{syntax/instructions}{syntax-memarg}{\X{memarg}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -409,8 +409,6 @@
 .. |frelop| mathdef:: \xref{syntax/instructions}{syntax-frelop}{\X{frelop}}
 
 .. |laneidx| mathdef:: \xref{syntax/instructions}{syntax-laneidx}{\X{laneidx}}
-.. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
-.. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
 .. |vsunop| mathdef:: \xref{syntax/instructions}{syntax-vsunop}{\X{vsunop}}
 .. |vsbinop| mathdef:: \xref{syntax/instructions}{syntax-vsbinop}{\X{vsbinop}}
 .. |vsternop| mathdef:: \xref{syntax/instructions}{syntax-vsternop}{\X{vsternop}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -129,6 +129,7 @@
 .. |sX#1| mathdef:: {\X{s#1}}
 .. |iX#1| mathdef:: {\X{i#1}}
 .. |fX#1| mathdef:: {\X{f#1}}
+.. |vX#1| mathdef:: {\X{v#1}}
 
 .. |uN| mathdef:: \xref{syntax/values}{syntax-int}{\X{u}N}
 .. |uM| mathdef:: \xref{syntax/values}{syntax-int}{\X{u}M}
@@ -378,6 +379,16 @@
 .. |DEMOTE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{demote}}
 .. |REINTERPRET| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{reinterpret}}
 
+.. |SHUFFLE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{shuffle}}
+.. |SWIZZLE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{swizzle}}
+.. |SPLAT| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{splat}}
+.. |EXTRACTLANE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{extract\_lane}}
+.. |REPLACELANE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{replace\_lane}}
+.. |BITMASK| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{bitmask}}
+.. |NARROW| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{narrow}}
+.. |WIDEN| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{widen}}
+.. |AVGRU| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{avgr\_u}}
+
 
 .. Instructions, non-terminals
 
@@ -396,6 +407,17 @@
 .. |fbinop| mathdef:: \xref{syntax/instructions}{syntax-fbinop}{\X{fbinop}}
 .. |ftestop| mathdef:: \xref{syntax/instructions}{syntax-ftestop}{\X{ftestop}}
 .. |frelop| mathdef:: \xref{syntax/instructions}{syntax-frelop}{\X{frelop}}
+
+.. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
+.. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
+.. |vternop| mathdef:: \xref{syntax/instructions}{syntax-vternop}{\X{vternop}}
+.. |vtestop| mathdef:: \xref{syntax/instructions}{syntax-vtestop}{\X{vtestop}}
+.. |vshiftop| mathdef:: \xref{syntax/instructions}{syntax-vshiftop}{\X{vshiftop}}
+.. |viunop| mathdef:: \xref{syntax/instructions}{syntax-viunop}{\X{viunop}}
+.. |vibinop| mathdef:: \xref{syntax/instructions}{syntax-vibinop}{\X{vibinop}}
+.. |vsatbinop| mathdef:: \xref{syntax/instructions}{syntax-vsatbinop}{\X{vsatbinop}}
+.. |vfunop| mathdef:: \xref{syntax/instructions}{syntax-vfunop}{\X{vfunop}}
+.. |vfbinop| mathdef:: \xref{syntax/instructions}{syntax-vfbinop}{\X{vfbinop}}
 
 .. |sx| mathdef:: \xref{syntax/instructions}{syntax-sx}{\X{sx}}
 .. |memarg| mathdef:: \xref{syntax/instructions}{syntax-memarg}{\X{memarg}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -408,6 +408,7 @@
 .. |ftestop| mathdef:: \xref{syntax/instructions}{syntax-ftestop}{\X{ftestop}}
 .. |frelop| mathdef:: \xref{syntax/instructions}{syntax-frelop}{\X{frelop}}
 
+.. |laneidx| mathdef:: \xref{syntax/instructions}{syntax-laneidx}{\X{laneidx}}
 .. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
 .. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
 .. |vsunop| mathdef:: \xref{syntax/instructions}{syntax-vsunop}{\X{vsunop}}


### PR DESCRIPTION
Main changes are defining:

- ixx for i8x16, i16x8, i32x4, i64x2
- fxx for f32x4, f64x2
- vxx for ixx and fxx
- the the rest of the SIMD instructions are defined based on these

Unfortunately, the definition of instructions aren't as clean as the existing ones, due to high asymmetry (see https://github.com/WebAssembly/simd/blob/master/proposals/simd/NewOpcodes.md for an overview).

This leads to a lot of specific i8x16, i16x8, i32x4 instructions defined (since i64x2 has to be left out).

I also tweaked the paragraph describing comparisons, to indicate that comparisons can return a boolean, or return a value of the same type, because the SIMD comparisons return S128. I'm not sure if this tweak should stick, we can also classify SIMD comparisons as Binary instructions, but that's confusing too. I guess I don't know if these subcategories are meant to classify instructions by "the kind of things they do" or "the type signature"?

See https://www.ngzhian.com/simd/core/syntax/instructions.html for a preview.