### PR TITLE
Set OCaml version to 4.08.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - yarn
 
 install:
-  - opam init --auto-setup --compiler=4.07.1
+  - opam init --auto-setup --compiler=4.08.1
   - eval $(opam env)
   - opam --version
   - ocaml --version


### PR DESCRIPTION
The Bytes [0] functions we use require 4.08.1. This should only be set
on SIMD repo, since bytes is only used for SIMD implementation. By the
time we would like to merge this back into main spec, 4.08.1 should
hopefully be widespread enough for us to bump minimum version of OCaml
for spec to 4.08.1 too.

[0] https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bytes.html see
"Binary encoding/decoding of integers"