### PR TITLE
Fix missing parser non-terminal rule for splat

### DIFF
--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -374,6 +374,7 @@ plain_instr :
   | BINARY { fun c -> $1 }
   | TERNARY { fun c -> $1 }
   | CONVERT { fun c -> $1 }
+  | SPLAT { fun c -> $1 }
   | EXTRACT_LANE NAT { let at = at () in fun c -> $1 (nat $2 at) }
   | SHIFT { fun c -> $1 }
 


### PR DESCRIPTION
This got lost in the rebase too, and #277 only partially fixed it.