### PR TITLE
Implement v8x16.swizzle

### DIFF
--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -146,6 +146,7 @@ struct
 
   let binop (op : binop) =
     let f = match op with
+      | I8x16 Swizzle -> SXX.V8x16.swizzle
       | I8x16 Eq -> SXX.I8x16.eq
       | I8x16 Ne -> SXX.I8x16.ne
       | I8x16 LtS -> SXX.I8x16.lt_s

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -132,6 +132,9 @@ sig
   module F32x4 : Float with type t = t and type lane = F32.t
   module F64x2 : Float with type t = t and type lane = F64.t
   module V128 : Vec with type t = t
+  module V8x16 : sig
+    val swizzle : t -> t -> t
+  end
 end
 
 module Make (Rep : RepType) : S with type bits = Rep.t =
@@ -241,6 +244,19 @@ struct
     let shr_s v s =
       let shift = Int.of_int_u (Int32.to_int s) in
       unop (fun a -> Int.shr_s a shift) v
+  end
+
+  module V8x16 = struct
+    let swizzle value index =
+      let vs = Rep.to_i8x16 value in
+      let is = Rep.to_i8x16 index in
+      let select i =
+        Option.(
+          value
+            (bind (Int32.unsigned_to_int i) (List.nth_opt vs))
+            ~default:Int32.zero)
+      in
+      Rep.of_i8x16 (List.map select is)
   end
 
   module I8x16 = MakeInt (I8) (struct

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -51,6 +51,7 @@ struct
   type iunop = Abs | Neg
   type ibinop = Add | Sub | MinS | MinU | MaxS | MaxU | Mul | AvgrU
               | Eq | Ne | LtS | LtU | LeS | LeU | GtS | GtU | GeS | GeU
+              | Swizzle
   type funop = Abs | Neg | Sqrt
   type fbinop = Add | Sub | Mul | Div | Min | Max
               | Eq | Ne | Lt | Le | Gt | Ge

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -224,6 +224,8 @@ let v128_or = Binary (V128 (V128Op.V128 V128Op.Or))
 let v128_xor = Binary (V128 (V128Op.V128 V128Op.Xor))
 let v128_bitselect = Ternary (V128Op.Bitselect)
 
+let v8x16_swizzle = Binary (V128 V128Op.(I8x16 Swizzle))
+
 let i8x16_splat = Convert (V128 (V128Op.I8x16 V128Op.Splat))
 let i8x16_eq = Binary (V128 V128Op.(I8x16 Eq))
 let i8x16_ne = Binary (V128 V128Op.(I8x16 Ne))

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -452,6 +452,7 @@ rule token = parse
   | (simd_float_shape as s)".le" { BINARY (simd_float_op s f32x4_le f64x2_le) }
   | (simd_float_shape as s)".gt" { BINARY (simd_float_op s f32x4_gt f64x2_gt) }
   | (simd_float_shape as s)".ge" { BINARY (simd_float_op s f32x4_ge f64x2_ge) }
+  | "v8x16.swizzle" { BINARY v8x16_swizzle }
   | vxxx".not" { UNARY v128_not }
   | vxxx".and" { UNARY v128_and }
   | vxxx".andnot" { UNARY v128_andnot }


### PR DESCRIPTION
Decided to cheat a little bit, and squeeze v8x16.swizzle into the i8x16
ast node, so that we don't have to create a new v8x16 data type.
Semantically it means the same thing, v8x16 is called that way since it
doesn't treat the underlying data as any particular type, so treating it
as int will work too.

Based on #282 (load and store), review 30a97f8 for changes.