### PR TITLE
i64x2.widen_(low/high)_i32x4_(s/u) instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -184,6 +184,10 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.dot_i16x8_s`         |    `0xba`| -                  |
 | `i64x2.neg`                 |    `0xc1`| -                  |
 | `i64x2.bitmask`             |    `0xc4`| -                  |
+| `i64x2.widen_low_i32x4_s`   |    `0xc7`| -                  |
+| `i64x2.widen_high_i32x4_s`  |    `0xc8`| -                  |
+| `i64x2.widen_low_i32x4_u`   |    `0xc9`| -                  |
+| `i64x2.widen_high_i32x4_u`  |    `0xca`| -                  |
 | `i64x2.shl`                 |    `0xcb`| -                  |
 | `i64x2.shr_s`               |    `0xcc`| -                  |
 | `i64x2.shr_u`               |    `0xcd`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -159,6 +159,10 @@
 | `i64x2.add`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.sub`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.mul`                 |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i64x2.widen_low_i32x4_s`   |                           |                    |                    |                    |                    |
+| `i64x2.widen_high_i32x4_s`  |                           |                    |                    |                    |                    |
+| `i64x2.widen_low_i32x4_u`   |                           |                    |                    |                    |                    |
+| `i64x2.widen_high_i32x4_u`  |                           |                    |                    |                    |                    |
 | `f32x4.abs`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.sqrt`                |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -78,36 +78,36 @@
 | v128.xor       | 0x51   |
 | v128.bitselect | 0x52   |
 
-| i8x16 Op             | opcode | i16x8 Op                 | opcode | i32x4 Op                 | opcode | i64x2 Op      | opcode |
-| -------------------- | ------ | ------------------------ | ------ | ------------------------ | ------ | ------------- | ------ |
-| i8x16.abs            | 0x60   | i16x8.abs                | 0x80   | i32x4.abs                | 0xa0   | ----          | 0xc0   |
-| i8x16.neg            | 0x61   | i16x8.neg                | 0x81   | i32x4.neg                | 0xa1   | i64x2.neg     | 0xc1   |
-| i8x16.any_true       | 0x62   | i16x8.any_true           | 0x82   | i32x4.any_true           | 0xa2   | ----          | 0xc2   |
-| i8x16.all_true       | 0x63   | i16x8.all_true           | 0x83   | i32x4.all_true           | 0xa3   | ----          | 0xc3   |
-| i8x16.bitmask        | 0x64   | i16x8.bitmask            | 0x84   | i32x4.bitmask            | 0xa4   | i64x2.bitmask | 0xc4   |
-| i8x16.narrow_i16x8_s | 0x65   | i16x8.narrow_i32x4_s     | 0x85   | ---- narrow ----         | 0xa5   | ----          | 0xc5   |
-| i8x16.narrow_i16x8_u | 0x66   | i16x8.narrow_i32x4_u     | 0x86   | ---- narrow ----         | 0xa6   | ----          | 0xc6   |
-| ---- widen ----      | 0x67   | i16x8.widen_low_i8x16_s  | 0x87   | i32x4.widen_low_i16x8_s  | 0xa7   | ----          | 0xc7   |
-| ---- widen ----      | 0x68   | i16x8.widen_high_i8x16_s | 0x88   | i32x4.widen_high_i16x8_s | 0xa8   | ----          | 0xc8   |
-| ---- widen ----      | 0x69   | i16x8.widen_low_i8x16_u  | 0x89   | i32x4.widen_low_i16x8_u  | 0xa9   | ----          | 0xc9   |
-| ---- widen ----      | 0x6a   | i16x8.widen_high_i8x16_u | 0x8a   | i32x4.widen_high_i16x8_u | 0xaa   | ----          | 0xca   |
-| i8x16.shl            | 0x6b   | i16x8.shl                | 0x8b   | i32x4.shl                | 0xab   | i64x2.shl     | 0xcb   |
-| i8x16.shr_s          | 0x6c   | i16x8.shr_s              | 0x8c   | i32x4.shr_s              | 0xac   | i64x2.shr_s   | 0xcc   |
-| i8x16.shr_u          | 0x6d   | i16x8.shr_u              | 0x8d   | i32x4.shr_u              | 0xad   | i64x2.shr_u   | 0xcd   |
-| i8x16.add            | 0x6e   | i16x8.add                | 0x8e   | i32x4.add                | 0xae   | i64x2.add     | 0xce   |
-| i8x16.add_sat_s      | 0x6f   | i16x8.add_sat_s          | 0x8f   | ---- add_sat ----        | 0xaf   | ----          | 0xcf   |
-| i8x16.add_sat_u      | 0x70   | i16x8.add_sat_u          | 0x90   | ---- add_sat ----        | 0xb0   | ----          | 0xd0   |
-| i8x16.sub            | 0x71   | i16x8.sub                | 0x91   | i32x4.sub                | 0xb1   | i64x2.sub     | 0xd1   |
-| i8x16.sub_sat_s      | 0x72   | i16x8.sub_sat_s          | 0x92   | ---- sub_sat ----        | 0xb2   | ----          | 0xd2   |
-| i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | ----          | 0xd3   |
-| -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | ----          | 0xd4   |
-| ---- mul ----        | 0x75   | i16x8.mul                | 0x95   | i32x4.mul                | 0xb5   | i64x2.mul     | 0xd5   |
-| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | ----          | 0xd6   |
-| i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | ----          | 0xd7   |
-| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | ----          | 0xd8   |
-| i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | ----          | 0xd9   |
-| ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | ----          | 0xda   |
-| i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | ----          | 0xdb   |
+| i8x16 Op             | opcode | i16x8 Op                 | opcode | i32x4 Op                 | opcode | i64x2 Op                 | opcode |
+| -------------------- | ------ | ------------------------ | ------ | ------------------------ | ------ | ------------------------ | ------ |
+| i8x16.abs            | 0x60   | i16x8.abs                | 0x80   | i32x4.abs                | 0xa0   | ----                     | 0xc0   |
+| i8x16.neg            | 0x61   | i16x8.neg                | 0x81   | i32x4.neg                | 0xa1   | i64x2.neg                | 0xc1   |
+| i8x16.any_true       | 0x62   | i16x8.any_true           | 0x82   | i32x4.any_true           | 0xa2   | ----                     | 0xc2   |
+| i8x16.all_true       | 0x63   | i16x8.all_true           | 0x83   | i32x4.all_true           | 0xa3   | ----                     | 0xc3   |
+| i8x16.bitmask        | 0x64   | i16x8.bitmask            | 0x84   | i32x4.bitmask            | 0xa4   | i64x2.bitmask            | 0xc4   |
+| i8x16.narrow_i16x8_s | 0x65   | i16x8.narrow_i32x4_s     | 0x85   | ---- narrow ----         | 0xa5   | ----                     | 0xc5   |
+| i8x16.narrow_i16x8_u | 0x66   | i16x8.narrow_i32x4_u     | 0x86   | ---- narrow ----         | 0xa6   | ----                     | 0xc6   |
+| ---- widen ----      | 0x67   | i16x8.widen_low_i8x16_s  | 0x87   | i32x4.widen_low_i16x8_s  | 0xa7   | i64x2.widen_low_i32x4_s  | 0xc7   |
+| ---- widen ----      | 0x68   | i16x8.widen_high_i8x16_s | 0x88   | i32x4.widen_high_i16x8_s | 0xa8   | i64x2.widen_high_i32x4_s | 0xc8   |
+| ---- widen ----      | 0x69   | i16x8.widen_low_i8x16_u  | 0x89   | i32x4.widen_low_i16x8_u  | 0xa9   | i64x2.widen_low_i32x4_u  | 0xc9   |
+| ---- widen ----      | 0x6a   | i16x8.widen_high_i8x16_u | 0x8a   | i32x4.widen_high_i16x8_u | 0xaa   | i64x2.widen_high_i32x4_u | 0xca   |
+| i8x16.shl            | 0x6b   | i16x8.shl                | 0x8b   | i32x4.shl                | 0xab   | i64x2.shl                | 0xcb   |
+| i8x16.shr_s          | 0x6c   | i16x8.shr_s              | 0x8c   | i32x4.shr_s              | 0xac   | i64x2.shr_s              | 0xcc   |
+| i8x16.shr_u          | 0x6d   | i16x8.shr_u              | 0x8d   | i32x4.shr_u              | 0xad   | i64x2.shr_u              | 0xcd   |
+| i8x16.add            | 0x6e   | i16x8.add                | 0x8e   | i32x4.add                | 0xae   | i64x2.add                | 0xce   |
+| i8x16.add_sat_s      | 0x6f   | i16x8.add_sat_s          | 0x8f   | ---- add_sat ----        | 0xaf   | ----                     | 0xcf   |
+| i8x16.add_sat_u      | 0x70   | i16x8.add_sat_u          | 0x90   | ---- add_sat ----        | 0xb0   | ----                     | 0xd0   |
+| i8x16.sub            | 0x71   | i16x8.sub                | 0x91   | i32x4.sub                | 0xb1   | i64x2.sub                | 0xd1   |
+| i8x16.sub_sat_s      | 0x72   | i16x8.sub_sat_s          | 0x92   | ---- sub_sat ----        | 0xb2   | ----                     | 0xd2   |
+| i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | ----                     | 0xd3   |
+| -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | ----                     | 0xd4   |
+| ---- mul ----        | 0x75   | i16x8.mul                | 0x95   | i32x4.mul                | 0xb5   | i64x2.mul                | 0xd5   |
+| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | ----                     | 0xd6   |
+| i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | ----                     | 0xd7   |
+| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | ----                     | 0xd8   |
+| i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | ----                     | 0xd9   |
+| ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | ----                     | 0xda   |
+| i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | ----                     | 0xdb   |
 
 | f32x4 Op        | opcode | f64x2 Op        | opcode |
 | --------------- | ------ | --------------- | ------ |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1065,6 +1065,10 @@ def S.narrow_T_u(a, b):
 * `i32x4.widen_high_i16x8_s(a: v128) -> v128`
 * `i32x4.widen_low_i16x8_u(a: v128) -> v128`
 * `i32x4.widen_high_i16x8_u(a: v128) -> v128`
+* `i64x2.widen_low_i32x4_s(a: v128) -> v128`
+* `i64x2.widen_high_i32x4_s(a: v128) -> v128`
+* `i64x2.widen_low_i32x4_u(a: v128) -> v128`
+* `i64x2.widen_high_i32x4_u(a: v128) -> v128`
 
 Converts low or high half of the smaller lane vector to a larger lane vector,
 sign extended or zero (unsigned) extended.


### PR DESCRIPTION
Introduction
=========

This is proposal to add new variants of existing `widen` instructions. The new variants convert the two low/high 32-bit integers in a SIMD vector to a vector of two 64-bit integers. It is unclear why these variants were left out of #89, as both x86 (since SSE4.1) and ARM NEON include the native equivalents. @AndrewScheidecker asked to reserve opcode space for these instructions, but it seems that there was no discussion about including/excluding the 64-bit forms.

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i64x2.widen_low_i32x4_s**
  - `y = i64x2.widen_low_i32x4_s(x)` is lowered to `VPMOVSXDQ xmm_y, xmm_x`
- **i64x2.widen_low_i32x4_u**
  - `y = i64x2.widen_low_i32x4_u(x)` is lowered to `VPMOVZXDQ xmm_y, xmm_x`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `VPUNPCKHQDQ xmm_y, xmm_x, xmm_x + VPMOVSXDQ xmm_y, xmm_y`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `VPXOR xmm_y, xmm_y, xmm_y + VPUNPCKHDQ xmm_y, xmm_x, xmm_y`

x86/x86-64 processors with SSE4.1 instruction set
--------------------------------------------------

- **i64x2.widen_low_i32x4_s**
  - `y = i64x2.widen_low_i32x4_s(x)` is lowered to `PMOVSXDQ xmm_y, xmm_x`
- **i64x2.widen_low_i32x4_u**
  - `y = i64x2.widen_low_i32x4_u(x)` is lowered to `PMOVZXDQ xmm_y, xmm_x`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `PSHUFD xmm_y, xmm_x, 0xEE + PMOVSXDQ xmm_y, xmm_y`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `PSHUFD xmm_y, xmm_x, 0xEE + PMOVZXDQ xmm_y, xmm_y`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **i64x2.widen_low_i32x4_s**
  - `y = i64x2.widen_low_i32x4_s(x)` is lowered to `PXOR x_tmp, x_tmp + MOVDQA xmm_y, xmm_x + PCMPGTD xmm_tmp, xmm_x + PUNPCKLDQ xmm_y, xmm_tmp`
- **i64x2.widen_low_i32x4_u**
  - `y = i64x2.widen_low_i32x4_u(x)` is lowered to `PXOR x_tmp, x_tmp + MOVDQA xmm_y, xmm_x + PUNPCKLDQ xmm_y, xmm_tmp`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `PXOR x_tmp, x_tmp + MOVDQA xmm_y, xmm_x + PCMPGTD xmm_tmp, xmm_x + PUNPCKHDQ xmm_y, xmm_tmp`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `PXOR x_tmp, x_tmp + MOVDQA xmm_y, xmm_x + PUNPCKHDQ xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------

- **i64x2.widen_low_i32x4_s**
  - `y = i64x2.widen_low_i32x4_s(x)` is lowered to `SSHLL Vy.2D, Vx.2S, 0`
- **i64x2.widen_low_i32x4_u**
  - `y = i64x2.widen_low_i32x4_u(x)` is lowered to `USHLL Vy.2D, Vx.2S, 0`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `SSHLL2 Vy.2D, Vx.2S, 0`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `USHLL2 Vy.2D, Vx.2S, 0`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **i64x2.widen_low_i32x4_s**
  - `y = i64x2.widen_low_i32x4_s(x)` is lowered to `VMOVL.S32 Qy, Dx_lo`
- **i64x2.widen_low_i32x4_u**
  - `y = i64x2.widen_low_i32x4_u(x)` is lowered to `VMOVL.U32 Qy, Dx_lo`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `VMOVL.S32 Qy, Dx_hi`
- **i64x2.widen_high_i32x4_s**
  - `y = i64x2.widen_high_i32x4_s(x)` is lowered to `VMOVL.U32 Qy, Dx_hi`
