### PR TITLE
Implement some binary<-> text support for SIMD

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -102,6 +102,7 @@ let vs33 s = I32_convert.wrap_i64 (vsN 33 s)
 let vs64 s = vsN 64 s
 let f32 s = F32.of_bits (u32 s)
 let f64 s = F64.of_bits (u64 s)
+let v128 s = V128.of_bits (get_string (Types.size Types.V128Type) s)
 
 let len32 s =
   let pos = pos s in
@@ -138,6 +139,7 @@ let value_type s =
   | -0x02 -> I64Type
   | -0x03 -> F32Type
   | -0x04 -> F64Type
+  | -0x05 -> V128Type
   | _ -> error s (pos s - 1) "malformed value type"
 
 let elem_type s =
@@ -214,6 +216,16 @@ let math_prefix s =
   | 0x05l -> i64_trunc_sat_f32_u
   | 0x06l -> i64_trunc_sat_f64_s
   | 0x07l -> i64_trunc_sat_f64_u
+  | n -> illegal s pos (I32.to_int_u n)
+
+let simd_prefix s =
+  let pos = pos s in
+  match vu32 s with
+  | 0x0cl -> v128_const (at v128 s)
+  | 0xa1l -> i32x4_neg
+  | 0xael -> i32x4_add
+  | 0xb1l -> i32x4_sub
+  | 0xb5l -> i32x4_mul
   | n -> illegal s pos (I32.to_int_u n)
 
 let rec instr s =
@@ -455,6 +467,7 @@ let rec instr s =
   | 0xc4 -> i64_extend32_s
 
   | 0xfc -> math_prefix s
+  | 0xfd -> simd_prefix s
 
   | b -> illegal s pos b
 

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -11,6 +11,14 @@ let lanes shape =
   | F32x4 -> 4
   | F64x2 -> 2
 
+let string_of_simd_shape = function
+  | I8x16 -> "i8x16"
+  | I16x8 -> "i16x8"
+  | I32x4 -> "i32x4"
+  | I64x2 -> "i64x2"
+  | F32x4 -> "f32x4"
+  | F64x2 -> "f64x2"
+
 module type RepType =
 sig
   type t
@@ -18,6 +26,7 @@ sig
   val make : int -> char -> t
   (* ^ bits_make ? *)
   val to_string : t -> string
+  val to_hex_string : t -> string
   val bytewidth : int
   val of_strings : shape -> string list -> t
 
@@ -120,6 +129,7 @@ sig
   type bits
   val default : t (* FIXME good name for default value? *)
   val to_string : t -> string
+  val to_hex_string : t -> string
   val of_bits : bits -> t
   val to_bits : t -> bits
   val of_strings : shape -> string list -> t
@@ -155,6 +165,7 @@ struct
 
   let default = Rep.make Rep.bytewidth (chr 0)
   let to_string = Rep.to_string (* FIXME very very wrong *)
+  let to_hex_string = Rep.to_hex_string
   let of_bits x = x
   let to_bits x = x
   let of_strings = Rep.of_strings

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -11,7 +11,7 @@ let lanes shape =
   | F32x4 -> 4
   | F64x2 -> 2
 
-let string_of_simd_shape = function
+let string_of_shape = function
   | I8x16 -> "i8x16"
   | I16x8 -> "i16x8"
   | I32x4 -> "i32x4"

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -2,7 +2,6 @@ include Simd.Make
   (struct
     include String
     let bytewidth = 16
-    let to_string s = s
 
     let to_i8x16 s =
       List.init 16 (fun i -> (Int32.of_int (Bytes.get_int8 (Bytes.of_string s) i)))
@@ -76,4 +75,15 @@ include Simd.Make
       | Simd.F64x2 ->
         List.iteri (fun i s -> set_int64_le b (i * 8) (F64.to_bits (F64.of_string s))) ss);
       Bytes.to_string b
+
+    (* This is needed for generating text format. In the text format, we can specify a shape,
+     * like "v128.const i8x16", but the binary format does not keep the shape, so we have to
+     * pick one when converting to text. Arbitrary pick i32x4, and make sure to be consistent.
+     *)
+    let to_string s =
+      let i32x4 = to_i32x4 s in
+      String.concat " " (List.map I32.to_string_s i32x4)
+    let to_hex_string s =
+      let i32x4 = to_i32x4 s in
+      String.concat " " (List.map I32.to_hex_string i32x4)
   end)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -286,7 +286,6 @@ let rec instr e =
     | Store op -> storeop op, []
     | MemorySize -> "memory.size", []
     | MemoryGrow -> "memory.grow", []
-    (* Special case for V128, which has a shape after the type *)
     | Const lit -> constop lit ^ " " ^ value lit, []
     | Test op -> testop op, []
     | Compare op -> relop op, []

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -250,10 +250,10 @@ let storeop op =
 let var x = nat32 x.it
 let value v = string_of_value v.it
 let constop v =
-  let typename = value_type (type_of v.it) in
-  match v.it with
-  | V128 _ -> typename ^ ".const i32x4 "
-  | _ -> typename ^ ".const "
+  let shape = match v.it with
+    | V128 _ -> "i32x4 "
+    | _ -> ""
+  in value_type (type_of v.it) ^ ".const " ^ shape
 
 let block_type = function
   | VarBlockType x -> [Node ("type " ^ var x, [])]

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -215,11 +215,11 @@ let oper (intop, floatop, simdop) op =
     | _ -> value_type (type_of op) ^ "."
   in
   let ops = match op with
-  | I32 o -> intop "32" o
-  | I64 o -> intop "64" o
-  | F32 o -> floatop "32" o
-  | F64 o -> floatop "64" o
-  | V128 o -> simdop "128" o
+    | I32 o -> intop "32" o
+    | I64 o -> intop "64" o
+    | F32 o -> floatop "32" o
+    | F64 o -> floatop "64" o
+    | V128 o -> simdop "128" o
   in prefix ^ ops
 
 let unop = oper (IntOp.unop, FloatOp.unop, SimdOp.unop)
@@ -477,20 +477,21 @@ let result_numpat mode res =
     match res with
     | LitPat lit -> constant mode lit
     | NanPat nanop ->
-        match nanop.it with
-        | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
-        | Values.F32 n -> Node ("f32.const " ^ nan n, [])
-        | Values.F64 n -> Node ("f64.const " ^ nan n, [])
+      match nanop.it with
+      | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
+      | Values.F32 n -> Node ("f32.const " ^ nan n, [])
+      | Values.F64 n -> Node ("f64.const " ^ nan n, [])
 
 let result_simd mode res shape pats =
   (* A different text generation for SIMD, since the literals within
    * a SimdResult do not need the i32.const instruction *)
   let num_pat mode res =
-      match res.it with
-      | LitPat lit -> literal mode lit
-      | NanPat {it = Values.F32 n; _}
-      | NanPat {it = Values.F64 n; _} -> nan n
-      | _ -> assert false in
+    match res.it with
+    | LitPat lit -> literal mode lit
+    | NanPat {it = Values.F32 n; _}
+    | NanPat {it = Values.F64 n; _} -> nan n
+    | _ -> assert false
+  in
   let lits = (List.map (num_pat mode) pats) in
   let tokens = ["v128.const"; Simd.string_of_shape shape;] @ lits in
   Node (String.concat " " tokens, [])

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -492,7 +492,7 @@ let result_simd mode res shape pats =
       | NanPat {it=Values.F64 n;_} -> nan n
       | _ -> assert false in
   let lits = (List.map (num_pat mode) pats) in
-  let tokens = ["v128.const"; Simd.string_of_simd_shape shape;] @ lits in
+  let tokens = ["v128.const"; Simd.string_of_shape shape;] @ lits in
   Node (String.concat " " tokens, [])
 
 let result mode res =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -211,8 +211,9 @@ let oper (intop, floatop, simdop) op =
    * each instruction will specify their prefix (shape).
    *)
   let prefix = match op with
-  | V128 o -> ""
-  | _ -> value_type (type_of op) ^ "." in
+    | V128 o -> ""
+    | _ -> value_type (type_of op) ^ "."
+  in
   let ops = match op with
   | I32 o -> intop "32" o
   | I64 o -> intop "64" o
@@ -422,11 +423,11 @@ let module_ = module_with_var_opt None
 let literal mode lit =
   let choose_mode bin not_bin = if mode = `Binary then bin else not_bin in
   match lit.it with
-  | Values.I32 i -> (choose_mode I32.to_hex_string I32.to_string_s) i
-  | Values.I64 i -> (choose_mode I64.to_hex_string I64.to_string_s) i
-  | Values.F32 z -> (choose_mode F32.to_hex_string F32.to_string) z
-  | Values.F64 z -> (choose_mode F64.to_hex_string F64.to_string) z
-  | Values.V128 v -> (choose_mode V128.to_hex_string V128.to_string) v
+  | Values.I32 i -> choose_mode I32.to_hex_string I32.to_string_s i
+  | Values.I64 i -> choose_mode I64.to_hex_string I64.to_string_s i
+  | Values.F32 z -> choose_mode F32.to_hex_string F32.to_string z
+  | Values.F64 z -> choose_mode F64.to_hex_string F64.to_string z
+  | Values.V128 v -> choose_mode V128.to_hex_string V128.to_string v
 
 (* Converts a literal into a constant instruction. *)
 let constant mode lit =
@@ -487,8 +488,8 @@ let result_simd mode res shape pats =
   let num_pat mode res =
       match res.it with
       | LitPat lit -> literal mode lit
-      | NanPat {it=Values.F32 n;_}
-      | NanPat {it=Values.F64 n;_} -> nan n
+      | NanPat {it = Values.F32 n; _}
+      | NanPat {it = Values.F64 n; _} -> nan n
       | _ -> assert false in
   let lits = (List.map (num_pat mode) pats) in
   let tokens = ["v128.const"; Simd.string_of_shape shape;] @ lits in

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -206,7 +206,7 @@ struct
   let cvtop xx = fun _ -> failwith "TODO v128"
 end
 
-let oper (intop, floatop, vectop) op =
+let oper (intop, floatop, simdop) op =
   (* v128 operations don't need to be prefixed by the type,
    * each instruction will specify their prefix (shape).
    *)
@@ -218,7 +218,7 @@ let oper (intop, floatop, vectop) op =
   | I64 o -> intop "64" o
   | F32 o -> floatop "32" o
   | F64 o -> floatop "64" o
-  | V128 o ->vectop "128" o
+  | V128 o -> simdop "128" o
   in prefix ^ ops
 
 let unop = oper (IntOp.unop, FloatOp.unop, SimdOp.unop)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -185,38 +185,47 @@ struct
 end
 
 (* FIXME *)
-module VectorOp =
+module SimdOp =
 struct
-  (* TODO
-  open Ast.FloatOp
-  *)
+  open Ast.SimdOp
 
   let testop xx = fun _ -> failwith "TODO v128"
 
   let relop xx = fun _ -> failwith "TODO v128"
 
-  let unop xx = fun _ -> failwith "TODO v128"
+  let unop xx (op : unop) = match op with
+    | I32x4 Neg -> "i32x4.neg"
+    | _ -> failwith "Unimplemented v128 unop"
 
-  let binop xx = fun _ -> failwith "TODO v128"
+  let binop xx (op : binop) = match op with
+    | I32x4 Add -> "i32x4.add"
+    | I32x4 Sub -> "i32x4.sub"
+    | I32x4 Mul -> "i32x4.mul"
+    | _ -> failwith "Unimplemented v128 unop"
 
   let cvtop xx = fun _ -> failwith "TODO v128"
 end
 
 let oper (intop, floatop, vectop) op =
-  value_type (type_of op) ^ "." ^
-  (match op with
+  (* v128 operations don't need to be prefixed by the type,
+   * each instruction will specify their prefix (shape).
+   *)
+  let prefix = match op with
+  | V128 o -> ""
+  | _ -> value_type (type_of op) ^ "." in
+  let ops = match op with
   | I32 o -> intop "32" o
   | I64 o -> intop "64" o
   | F32 o -> floatop "32" o
   | F64 o -> floatop "64" o
-  | V128 o -> vectop "128" o
-  )
+  | V128 o ->vectop "128" o
+  in prefix ^ ops
 
-let unop = oper (IntOp.unop, FloatOp.unop, VectorOp.unop)
-let binop = oper (IntOp.binop, FloatOp.binop, VectorOp.binop)
-let testop = oper (IntOp.testop, FloatOp.testop, VectorOp.testop)
-let relop = oper (IntOp.relop, FloatOp.relop, VectorOp.relop)
-let cvtop = oper (IntOp.cvtop, FloatOp.cvtop, VectorOp.cvtop)
+let unop = oper (IntOp.unop, FloatOp.unop, SimdOp.unop)
+let binop = oper (IntOp.binop, FloatOp.binop, SimdOp.binop)
+let testop = oper (IntOp.testop, FloatOp.testop, SimdOp.testop)
+let relop = oper (IntOp.relop, FloatOp.relop, SimdOp.relop)
+let cvtop = oper (IntOp.cvtop, FloatOp.cvtop, SimdOp.cvtop)
 
 let memop name {ty; align; offset; _} sz =
   value_type ty ^ "." ^ name ^
@@ -273,6 +282,8 @@ let rec instr e =
     | Store op -> storeop op, []
     | MemorySize -> "memory.size", []
     | MemoryGrow -> "memory.grow", []
+    (* Special case for V128, which has a shape after the type *)
+    | Const (({it=V128(_); at}) as lit) -> constop lit ^ " i32x4 " ^ value lit, []
     | Const lit -> constop lit ^ " " ^ value lit, []
     | Test op -> testop op, []
     | Compare op -> relop op, []
@@ -405,23 +416,23 @@ let module_ = module_with_var_opt None
 
 (* Scripts *)
 
+(* Converts a value to string depending on mode. *)
 let literal mode lit =
+  let choose_mode bin not_bin = if mode = `Binary then bin else not_bin in
   match lit.it with
-  | Values.I32 i ->
-    let f = if mode = `Binary then I32.to_hex_string else I32.to_string_s in
-    Node ("i32.const " ^ f i, [])
-  | Values.I64 i ->
-    let f = if mode = `Binary then I64.to_hex_string else I64.to_string_s in
-    Node ("i64.const " ^ f i, [])
-  | Values.F32 z ->
-    let f = if mode = `Binary then F32.to_hex_string else F32.to_string in
-    Node ("f32.const " ^ f z, [])
-  | Values.F64 z ->
-    let f = if mode = `Binary then F64.to_hex_string else F64.to_string in
-    Node ("f64.const " ^ f z, [])
-  | Values.V128 v -> 
-    let f = if mode = `Binary then (failwith "unimplemented v128 binary mode") else V128.to_string in
-    Node ("v128.const " ^ f v, [])
+  | Values.I32 i -> (choose_mode I32.to_hex_string I32.to_string_s) i
+  | Values.I64 i -> (choose_mode I64.to_hex_string I64.to_string_s) i
+  | Values.F32 z -> (choose_mode F32.to_hex_string F32.to_string) z
+  | Values.F64 z -> (choose_mode F64.to_hex_string F64.to_string) z
+  | Values.V128 v -> (choose_mode V128.to_hex_string V128.to_string) v
+
+(* Converts a literal into a constant instruction. *)
+let constant mode lit =
+  let type_name = string_of_value_type (type_of lit.it) in
+  let lit_string = literal mode lit in
+  match lit.it with
+  | Values.V128 v -> Node ("v128.const i32x4 " ^ lit_string, [])
+  | _ -> Node (type_name ^ ".const " ^ lit_string, [])
 
 let definition mode x_opt def =
   try
@@ -454,7 +465,7 @@ let access x_opt n =
 let action mode act =
   match act.it with
   | Invoke (x_opt, name, lits) ->
-    Node ("invoke" ^ access x_opt name, List.map (literal mode) lits)
+    Node ("invoke" ^ access x_opt name, List.map (constant mode) lits)
   | Get (x_opt, name) ->
     Node ("get" ^ access x_opt name, [])
 
@@ -464,16 +475,29 @@ let nan = function
 
 let result_numpat mode res =
     match res with
-    | LitPat lit -> literal mode lit
+    | LitPat lit -> constant mode lit
     | NanPat nanop ->
         match nanop.it with
         | Values.I32 _ | Values.I64 _ | Values.V128 _ -> assert false
         | Values.F32 n -> Node ("f32.const " ^ nan n, [])
         | Values.F64 n -> Node ("f64.const " ^ nan n, [])
 
+let result_simd mode res shape pats =
+  (* A different text generation for SIMD, since the literals within
+   * a SimdResult do not need the i32.const instruction *)
+  let num_pat mode res =
+      match res.it with
+      | LitPat lit -> literal mode lit
+      | NanPat {it=Values.F32 n;_}
+      | NanPat {it=Values.F64 n;_} -> nan n
+      | _ -> assert false in
+  let lits = (List.map (num_pat mode) pats) in
+  let tokens = ["v128.const"; Simd.string_of_simd_shape shape;] @ lits in
+  Node (String.concat " " tokens, [])
+
 let result mode res =
   match res.it with
-  | SimdResult _ -> failwith "unimplemented"
+  | SimdResult (shape, pats) -> result_simd mode res shape pats
   | NumResult n -> result_numpat mode n.it
 
 let assertion mode ass =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -251,8 +251,8 @@ let value v = string_of_value v.it
 let constop v =
   let typename = value_type (type_of v.it) in
   match v.it with
-  | V128 _ -> typename ^ ".const i32x4"
-  | _ -> typename ^ ".const"
+  | V128 _ -> typename ^ ".const i32x4 "
+  | _ -> typename ^ ".const "
 
 let block_type = function
   | VarBlockType x -> [Node ("type " ^ var x, [])]
@@ -286,7 +286,7 @@ let rec instr e =
     | Store op -> storeop op, []
     | MemorySize -> "memory.size", []
     | MemoryGrow -> "memory.grow", []
-    | Const lit -> constop lit ^ " " ^ value lit, []
+    | Const lit -> constop lit ^ value lit, []
     | Test op -> testop op, []
     | Compare op -> relop op, []
     | Unary op -> unop op, []

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -92,12 +92,13 @@ class RunTests(unittest.TestCase):
     self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, wasm2Path, wast2Path), logPath)
     self._compareFile(wastPath, wast2Path)
 
-    # Convert to JavaScript
-    jsPath = self._auxFile(outputPath.replace(".wast", ".js"))
-    logPath = self._auxFile(jsPath + ".log")
-    self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, inputPath, jsPath), logPath)
-    if jsCommand != None:
-      self._runCommand(('%s "%s"') % (jsCommand, jsPath), logPath)
+    # Convert to JavaScript, SIMD has no JS support at all, so don't generate JS files.
+    if 'simd' not in outputPath:
+        jsPath = self._auxFile(outputPath.replace(".wast", ".js"))
+        logPath = self._auxFile(jsPath + ".log")
+        self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, inputPath, jsPath), logPath)
+        if jsCommand != None:
+          self._runCommand(('%s "%s"') % (jsCommand, jsPath), logPath)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is sufficient to pass test/core/simd/simd_i32x4_arith.wast.