### PR TITLE
Implement some i32x4 binary<->text support for SIMD

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -222,10 +222,15 @@ let simd_prefix s =
   let pos = pos s in
   match vu32 s with
   | 0x0cl -> v128_const (at v128 s)
+  | 0xa0l -> i32x4_abs
   | 0xa1l -> i32x4_neg
   | 0xael -> i32x4_add
   | 0xb1l -> i32x4_sub
   | 0xb5l -> i32x4_mul
+  | 0xb6l -> i32x4_min_s
+  | 0xb7l -> i32x4_min_u
+  | 0xb8l -> i32x4_max_s
+  | 0xb9l -> i32x4_max_u
   | n -> illegal s pos (I32.to_int_u n)
 
 let rec instr s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -296,6 +296,7 @@ let encode m =
       | Unary (F64 F64Op.Nearest) -> op 0x9e
       | Unary (F64 F64Op.Sqrt) -> op 0x9f
 
+      | Unary (V128 V128Op.(I32x4 Abs)) -> simd_op 0xa0l
       | Unary (V128 V128Op.(I32x4 Neg)) -> simd_op 0xa1l
       | Unary (V128 _) -> failwith "unimplemented V128 Unary op"
 
@@ -349,6 +350,10 @@ let encode m =
 
       | Binary (V128 V128Op.(I32x4 Add)) -> simd_op 0xael
       | Binary (V128 V128Op.(I32x4 Sub)) -> simd_op 0xb1l
+      | Binary (V128 V128Op.(I32x4 MinS)) -> simd_op 0xb6l
+      | Binary (V128 V128Op.(I32x4 MinU)) -> simd_op 0xb7l
+      | Binary (V128 V128Op.(I32x4 MaxS)) -> simd_op 0xb8l
+      | Binary (V128 V128Op.(I32x4 MaxU)) -> simd_op 0xb9l
       | Binary (V128 V128Op.(I32x4 Mul)) -> simd_op 0xb5l
       | Binary (V128 _) -> failwith "TODO v128"
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -194,6 +194,7 @@ struct
   let relop xx = fun _ -> failwith "TODO v128"
 
   let unop xx (op : unop) = match op with
+    | I32x4 Abs -> "i32x4.abs"
     | I32x4 Neg -> "i32x4.neg"
     | _ -> failwith "Unimplemented v128 unop"
 
@@ -201,6 +202,10 @@ struct
     | I32x4 Add -> "i32x4.add"
     | I32x4 Sub -> "i32x4.sub"
     | I32x4 Mul -> "i32x4.mul"
+    | I32x4 MinS -> "i32x4.min_s"
+    | I32x4 MinU -> "i32x4.min_u"
+    | I32x4 MaxS -> "i32x4.max_s"
+    | I32x4 MaxU -> "i32x4.max_u"
     | _ -> failwith "Unimplemented v128 unop"
 
   let cvtop xx = fun _ -> failwith "TODO v128"


### PR DESCRIPTION
This is sufficient to pass test/core/simd/simd_i32x4_arith2.wast.