### PR TITLE
Implement more binary<->text support for SIMD

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -250,6 +250,10 @@ let simd_prefix s =
   | 0xb7l -> i32x4_min_u
   | 0xb8l -> i32x4_max_s
   | 0xb9l -> i32x4_max_u
+  | 0xc1l -> i64x2_neg
+  | 0xcel -> i64x2_add
+  | 0xd1l -> i64x2_sub
+  | 0xd5l -> i64x2_mul
   | n -> illegal s pos (I32.to_int_u n)
 
 let rec instr s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -302,6 +302,7 @@ let encode m =
       | Unary (V128 V128Op.(I16x8 Neg)) -> simd_op 0x81l
       | Unary (V128 V128Op.(I32x4 Abs)) -> simd_op 0xa0l
       | Unary (V128 V128Op.(I32x4 Neg)) -> simd_op 0xa1l
+      | Unary (V128 V128Op.(I64x2 Neg)) -> simd_op 0xc1l
       | Unary (V128 _) -> failwith "unimplemented V128 Unary op"
 
       | Binary (I32 I32Op.Add) -> op 0x6a
@@ -374,6 +375,9 @@ let encode m =
       | Binary (V128 V128Op.(I32x4 MaxS)) -> simd_op 0xb8l
       | Binary (V128 V128Op.(I32x4 MaxU)) -> simd_op 0xb9l
       | Binary (V128 V128Op.(I32x4 Mul)) -> simd_op 0xb5l
+      | Binary (V128 V128Op.(I64x2 Add)) -> simd_op 0xcel
+      | Binary (V128 V128Op.(I64x2 Sub)) -> simd_op 0xd1l
+      | Binary (V128 V128Op.(I64x2 Mul)) -> simd_op 0xd5l
       | Binary (V128 _) -> failwith "TODO v128"
 
       | Ternary (_) -> failwith "TODO v128"

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -200,6 +200,7 @@ struct
     | I16x8 Neg -> "i16x8.neg"
     | I32x4 Abs -> "i32x4.abs"
     | I32x4 Neg -> "i32x4.neg"
+    | I64x2 Neg -> "i64x2.neg"
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
@@ -225,6 +226,9 @@ struct
     | I32x4 MinU -> "i32x4.min_u"
     | I32x4 MaxS -> "i32x4.max_s"
     | I32x4 MaxU -> "i32x4.max_u"
+    | I64x2 Add -> "i64x2.add"
+    | I64x2 Sub -> "i64x2.sub"
+    | I64x2 Mul -> "i64x2.mul"
     | _ -> failwith "Unimplemented v128 binop"
 
   let cvtop xx = fun _ -> failwith "TODO v128"


### PR DESCRIPTION
This is sufficient to pass test/core/simd/simd_i64x2_arith.wast.