### PR TITLE
Implement binary<->text support for SIMD f32x4 arithmetic and compare ops

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -221,7 +221,14 @@ let math_prefix s =
 let simd_prefix s =
   let pos = pos s in
   match vu32 s with
+  | 0x00l -> let a, o = memop s in v128_load a o
   | 0x0cl -> v128_const (at v128 s)
+  | 0x41l -> f32x4_eq
+  | 0x42l -> f32x4_ne
+  | 0x43l -> f32x4_lt
+  | 0x44l -> f32x4_gt
+  | 0x45l -> f32x4_le
+  | 0x46l -> f32x4_ge
   | 0x60l -> i8x16_abs
   | 0x61l -> i8x16_neg
   | 0x6el -> i8x16_add
@@ -254,6 +261,15 @@ let simd_prefix s =
   | 0xcel -> i64x2_add
   | 0xd1l -> i64x2_sub
   | 0xd5l -> i64x2_mul
+  | 0xe0l -> f32x4_abs
+  | 0xe1l -> f32x4_neg
+  | 0xe3l -> f32x4_sqrt
+  | 0xe4l -> f32x4_add
+  | 0xe5l -> f32x4_sub
+  | 0xe6l -> f32x4_mul
+  | 0xe7l -> f32x4_div
+  | 0xe8l -> f32x4_min
+  | 0xe9l -> f32x4_max
   | n -> illegal s pos (I32.to_int_u n)
 
 let rec instr s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -303,6 +303,9 @@ let encode m =
       | Unary (V128 V128Op.(I32x4 Abs)) -> simd_op 0xa0l
       | Unary (V128 V128Op.(I32x4 Neg)) -> simd_op 0xa1l
       | Unary (V128 V128Op.(I64x2 Neg)) -> simd_op 0xc1l
+      | Unary (V128 V128Op.(F32x4 Abs)) -> simd_op 0xe0l
+      | Unary (V128 V128Op.(F32x4 Neg)) -> simd_op 0xe1l
+      | Unary (V128 V128Op.(F32x4 Sqrt)) -> simd_op 0xe3l
       | Unary (V128 _) -> failwith "unimplemented V128 Unary op"
 
       | Binary (I32 I32Op.Add) -> op 0x6a
@@ -378,6 +381,18 @@ let encode m =
       | Binary (V128 V128Op.(I64x2 Add)) -> simd_op 0xcel
       | Binary (V128 V128Op.(I64x2 Sub)) -> simd_op 0xd1l
       | Binary (V128 V128Op.(I64x2 Mul)) -> simd_op 0xd5l
+      | Binary (V128 V128Op.(F32x4 Eq)) -> simd_op 0x41l
+      | Binary (V128 V128Op.(F32x4 Ne)) -> simd_op 0x42l
+      | Binary (V128 V128Op.(F32x4 Lt)) -> simd_op 0x43l
+      | Binary (V128 V128Op.(F32x4 Gt)) -> simd_op 0x44l
+      | Binary (V128 V128Op.(F32x4 Le)) -> simd_op 0x45l
+      | Binary (V128 V128Op.(F32x4 Ge)) -> simd_op 0x46l
+      | Binary (V128 V128Op.(F32x4 Add)) -> simd_op 0xe4l
+      | Binary (V128 V128Op.(F32x4 Sub)) -> simd_op 0xe5l
+      | Binary (V128 V128Op.(F32x4 Mul)) -> simd_op 0xe6l
+      | Binary (V128 V128Op.(F32x4 Div)) -> simd_op 0xe7l
+      | Binary (V128 V128Op.(F32x4 Min)) -> simd_op 0xe8l
+      | Binary (V128 V128Op.(F32x4 Max)) -> simd_op 0xe9l
       | Binary (V128 _) -> failwith "TODO v128"
 
       | Ternary (_) -> failwith "TODO v128"

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -201,6 +201,9 @@ struct
     | I32x4 Abs -> "i32x4.abs"
     | I32x4 Neg -> "i32x4.neg"
     | I64x2 Neg -> "i64x2.neg"
+    | F32x4 Abs -> "f32x4.abs"
+    | F32x4 Neg -> "f32x4.neg"
+    | F32x4 Sqrt -> "f32x4.sqrt"
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
@@ -229,6 +232,18 @@ struct
     | I64x2 Add -> "i64x2.add"
     | I64x2 Sub -> "i64x2.sub"
     | I64x2 Mul -> "i64x2.mul"
+    | F32x4 Eq -> "f32x4.eq"
+    | F32x4 Ne -> "f32x4.ne"
+    | F32x4 Lt -> "f32x4.lt"
+    | F32x4 Le -> "f32x4.le"
+    | F32x4 Gt -> "f32x4.gt"
+    | F32x4 Ge -> "f32x4.ge"
+    | F32x4 Add -> "f32x4.add"
+    | F32x4 Sub -> "f32x4.sub"
+    | F32x4 Mul -> "f32x4.mul"
+    | F32x4 Div -> "f32x4.div"
+    | F32x4 Min -> "f32x4.min"
+    | F32x4 Max -> "f32x4.max"
     | _ -> failwith "Unimplemented v128 binop"
 
   let cvtop xx = fun _ -> failwith "TODO v128"


### PR DESCRIPTION
This is sufficient to pass simd_f32x4.wast, simd_f32x4_arith.wast, and
simd_f32x4_cmp.wast.