### PR TITLE
Implement SIMD load splat and load extend

### DIFF
--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -200,6 +200,8 @@ let encode m =
       | Load ({ty = V128Type; _} as mo) ->
         simd_op 0x00l; memop mo
 
+      | SimdLoad _ -> failwith "TODO v128 SimdLoad"
+
       | Store ({ty = I32Type; sz = None; _} as mo) -> op 0x36; memop mo
       | Store ({ty = I64Type; sz = None; _} as mo) -> op 0x37; memop mo
       | Store ({ty = F32Type; sz = None; _} as mo) -> op 0x38; memop mo

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -220,6 +220,17 @@ let rec step (c : config) : config =
           in v :: vs', []
         with exn -> vs', [Trapping (memory_error e.at exn) @@ e.at])
 
+      | SimdLoad {offset; ty; sz; _}, I32 i :: vs' ->
+        let mem = memory frame.inst (0l @@ e.at) in
+        let addr = I64_convert.extend_i32_u i in
+        (try
+          let v =
+            match sz with
+            | None -> assert false
+            | Some load_kind -> Memory.load_simd load_kind mem addr offset ty
+          in v :: vs', []
+        with exn -> vs', [Trapping (memory_error e.at exn) @@ e.at])
+
       | Store {offset; sz; _}, v :: I32 i :: vs' ->
         let mem = memory frame.inst (0l @@ e.at) in
         let addr = I64_convert.extend_i32_u i in

--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -173,6 +173,10 @@ sig
     val widen_low_u : t -> t
     val widen_high_u : t -> t
   end
+  module I64x2_convert : sig
+    val widen_low_s : t -> t
+    val widen_low_u : t -> t
+  end
   module F32x4_convert : sig
     val convert_i32x4_s : t -> t
     val convert_i32x4_u : t -> t
@@ -393,6 +397,16 @@ struct
     let widen_high_s = widen Lib.List.drop 0xffffffffl
     let widen_low_u = widen Lib.List.take 0xffffl
     let widen_high_u = widen Lib.List.drop 0xffffl
+  end
+
+  module I64x2_convert = struct
+    let widen mask x =
+      Rep.of_i64x2
+        (List.map
+           (fun i32 -> Int64.(logand mask (of_int32 i32)))
+           (Lib.List.take 2 (Rep.to_i32x4 x)))
+    let widen_low_s = widen 0xffffffffffffffffL
+    let widen_low_u = widen 0xffffffffL
   end
 
   module F32x4_convert = struct

--- a/interpreter/runtime/memory.mli
+++ b/interpreter/runtime/memory.mli
@@ -35,6 +35,9 @@ val store_value :
 val load_packed :
   pack_size -> extension -> memory -> address -> offset -> value_type -> value
     (* raises Type, Bounds *)
+val load_simd :
+  simd_load_kind -> memory -> address -> offset -> value_type -> value
+    (* raises Type, Bounds *)
 val store_packed :
   pack_size -> memory -> address -> offset -> value -> unit
     (* raises Type, Bounds *)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -107,6 +107,7 @@ type 'a memop =
   {ty : value_type; align : int; offset : Memory.offset; sz : 'a option}
 type loadop = (pack_size * extension) memop
 type storeop = pack_size memop
+type simdloadop = simd_load_kind memop
 
 
 (* Expressions *)
@@ -138,6 +139,7 @@ and instr' =
   | GlobalGet of var                  (* read global variable *)
   | GlobalSet of var                  (* write global variable *)
   | Load of loadop                    (* read memory at address *)
+  | SimdLoad of simdloadop            (* read memory at address *)
   | Store of storeop                  (* write memory at address *)
   | MemorySize                        (* size of linear memory *)
   | MemoryGrow                        (* grow linear memory *)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -229,6 +229,30 @@ let v128_bitselect = Ternary (V128Op.Bitselect)
 let v8x16_swizzle = Binary (V128 V128Op.(I8x16 Swizzle))
 let v8x16_shuffle imms = Binary (V128 V128Op.(I8x16 (Shuffle imms)))
 
+let i16x8_load8x8_s align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack8, SX))}
+let i16x8_load8x8_u align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack8, ZX))}
+
+let i32x4_load16x4_s align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack16, SX))}
+let i32x4_load16x4_u align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack16, ZX))}
+
+let i64x2_load32x2_s align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack32, SX))}
+let i64x2_load32x2_u align offset =
+  SimdLoad {ty = V128Type; align; offset; sz = Some (LoadExtend (SimdPack32, ZX))}
+
+let v8x16_load_splat align offset =
+  SimdLoad {ty= V128Type; align; offset; sz = Some (LoadSplat SimdPack8)}
+let v16x8_load_splat align offset =
+  SimdLoad {ty= V128Type; align; offset; sz = Some (LoadSplat SimdPack16)}
+let v32x4_load_splat align offset =
+  SimdLoad {ty= V128Type; align; offset; sz = Some (LoadSplat SimdPack32)}
+let v64x2_load_splat align offset =
+  SimdLoad {ty= V128Type; align; offset; sz = Some (LoadSplat SimdPack64)}
+
 let i8x16_splat = Convert (V128 (V128Op.I8x16 V128Op.Splat))
 let i8x16_extract_lane_s imm = SimdExtract (V128Op.I8x16 (SX, imm))
 let i8x16_extract_lane_u imm = SimdExtract (V128Op.I8x16 (ZX, imm))

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -19,6 +19,12 @@ type extern_type =
 type pack_size = Pack8 | Pack16 | Pack32
 type extension = SX | ZX
 
+type simd_pack_size =
+  | SimdPack8 | SimdPack16 | SimdPack32 | SimdPack64
+type simd_load_kind =
+    LoadSplat of simd_pack_size
+  | LoadExtend of simd_pack_size * extension
+
 
 (* Attributes *)
 
@@ -32,6 +38,11 @@ let packed_size = function
   | Pack16 -> 2
   | Pack32 -> 4
 
+let simd_packed_size = function
+  | SimdPack8 -> 1
+  | SimdPack16 -> 2
+  | SimdPack32 -> 4
+  | SimdPack64 -> 8
 
 (* Subtyping *)
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -321,6 +321,7 @@ let rec instr e =
     | SimdExtract op -> failwith "TODO v128"
     | SimdReplace op -> failwith "TODO v128"
     | SimdShift op -> failwith "TODO v128"
+    | SimdLoad _ -> failwith "TODO v128 SimdLoad"
   in Node (head, inner)
 
 let const c =

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -288,6 +288,20 @@ rule token = parse
             (ext s i64_load8_s i64_load8_u (opt a 0))
             (ext s i64_load16_s i64_load16_u (opt a 1))
             (ext s i64_load32_s i64_load32_u (opt a 2)) o)) }
+  | "i16x8.load8x8_"(sign as s)
+  { LOAD (fun a o -> (ext s i16x8_load8x8_s i16x8_load8x8_u (opt a 3)) o) }
+  | "i32x4.load16x4_"(sign as s)
+  { LOAD (fun a o -> (ext s i32x4_load16x4_s i32x4_load16x4_u (opt a 3)) o) }
+  | "i64x2.load32x2_"(sign as s)
+  { LOAD (fun a o -> (ext s i64x2_load32x2_s i64x2_load32x2_u (opt a 3)) o) }
+  | "v8x16.load_splat"
+  { LOAD (fun a o -> (v8x16_load_splat (opt a 0)) o) }
+  | "v16x8.load_splat"
+  { LOAD (fun a o -> (v16x8_load_splat (opt a 1)) o) }
+  | "v32x4.load_splat"
+  { LOAD (fun a o -> (v32x4_load_splat (opt a 2)) o) }
+  | "v64x2.load_splat"
+  { LOAD (fun a o -> (v64x2_load_splat (opt a 3)) o) }
   | (ixx as t)".store"(mem_size as sz)
     { if t = "i32" && sz = "32" then error lexbuf "unknown operator";
       STORE (fun a o ->


### PR DESCRIPTION
Introduce a new SimdLoad AST node to represent SIMD load splat and load
extend. The existing parameters for loadop is not sufficient to
represent all the load splats and extends, as it only has 3 pack sizes,
and 2 sign-extensions, and 1 none case, giving at total of 7 cases:

- sz = (pack_size * extension) option

while we have 6 load extends and 4 load splats (10 in total).

We can add 1 more case to pack_size, Pack64, which will only be used by
SIMD loads, but that still only gives 8 cases. We can also add 1 more
data type to extension, that will give us enough, but it will be useless
for non-v128 loads.