### PR TITLE
Implement binary<->text support for SIMD bitwise ops

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -265,6 +265,12 @@ let simd_prefix s =
   | 0x4al -> f64x2_gt
   | 0x4bl -> f64x2_le
   | 0x4cl -> f64x2_ge
+  | 0x4dl -> v128_not
+  | 0x4el -> v128_and
+  | 0x4fl -> v128_andnot
+  | 0x50l -> v128_or
+  | 0x51l -> v128_xor
+  | 0x52l -> v128_bitselect
   | 0x60l -> i8x16_abs
   | 0x61l -> i8x16_neg
   | 0x6el -> i8x16_add

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -296,6 +296,7 @@ let encode m =
       | Unary (F64 F64Op.Nearest) -> op 0x9e
       | Unary (F64 F64Op.Sqrt) -> op 0x9f
 
+      | Unary (V128 V128Op.(V128 Not)) -> simd_op 0x4dl
       | Unary (V128 V128Op.(I8x16 Abs)) -> simd_op 0x60l
       | Unary (V128 V128Op.(I8x16 Neg)) -> simd_op 0x61l
       | Unary (V128 V128Op.(I16x8 Abs)) -> simd_op 0x80l
@@ -438,9 +439,14 @@ let encode m =
       | Binary (V128 V128Op.(F64x2 Div)) -> simd_op 0xf3l
       | Binary (V128 V128Op.(F64x2 Min)) -> simd_op 0xf4l
       | Binary (V128 V128Op.(F64x2 Max)) -> simd_op 0xf5l
+      | Binary (V128 V128Op.(V128 And)) -> simd_op 0x4el
+      | Binary (V128 V128Op.(V128 AndNot)) -> simd_op 0x4fl
+      | Binary (V128 V128Op.(V128 Or)) -> simd_op 0x50l
+      | Binary (V128 V128Op.(V128 Xor)) -> simd_op 0x51l
       | Binary (V128 _) -> failwith "TODO v128"
 
-      | Ternary (_) -> failwith "TODO v128"
+
+      | Ternary (V128Op.Bitselect) -> simd_op 0x52l
 
       | Convert (I32 I32Op.ExtendSI32) -> assert false
       | Convert (I32 I32Op.ExtendUI32) -> assert false

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -207,6 +207,7 @@ struct
     | F64x2 Abs -> "f64x2.abs"
     | F64x2 Neg -> "f64x2.neg"
     | F64x2 Sqrt -> "f64x2.sqrt"
+    | V128 Not -> "v128.not"
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
@@ -289,7 +290,14 @@ struct
     | F64x2 Div -> "f64x2.div"
     | F64x2 Min -> "f64x2.min"
     | F64x2 Max -> "f64x2.max"
+    | V128 And -> "v128.and"
+    | V128 AndNot -> "v128.andnot"
+    | V128 Or -> "v128.or"
+    | V128 Xor -> "v128.xor"
     | _ -> failwith "Unimplemented v128 binop"
+
+  let ternop (op : ternop) = match op with
+    | Bitselect -> "v128.bitselect"
 
   let cvtop xx = fun _ -> failwith "TODO v128"
 end
@@ -315,6 +323,7 @@ let binop = oper (IntOp.binop, FloatOp.binop, SimdOp.binop)
 let testop = oper (IntOp.testop, FloatOp.testop, SimdOp.testop)
 let relop = oper (IntOp.relop, FloatOp.relop, SimdOp.relop)
 let cvtop = oper (IntOp.cvtop, FloatOp.cvtop, SimdOp.cvtop)
+let ternop = SimdOp.ternop
 
 let memop name {ty; align; offset; _} sz =
   value_type ty ^ "." ^ name ^
@@ -380,7 +389,7 @@ let rec instr e =
     | Compare op -> relop op, []
     | Unary op -> unop op, []
     | Binary op -> binop op, []
-    | Ternary op -> failwith "TODO v128 ternary op"
+    | Ternary op -> ternop op, []
     | Convert op -> cvtop op, []
     | SimdExtract op -> failwith "TODO v128"
     | SimdReplace op -> failwith "TODO v128"


### PR DESCRIPTION
This is sufficient to pass simd_bitwise.wast.