### PR TITLE
Implement binary<->text support for SIMD boolean ops

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -273,6 +273,8 @@ let simd_prefix s =
   | 0x52l -> v128_bitselect
   | 0x60l -> i8x16_abs
   | 0x61l -> i8x16_neg
+  | 0x62l -> i8x16_any_true
+  | 0x63l -> i8x16_all_true
   | 0x6el -> i8x16_add
   | 0x71l -> i8x16_sub
   | 0x76l -> i8x16_min_s
@@ -282,6 +284,8 @@ let simd_prefix s =
   | 0x7bl -> i8x16_avgr_u
   | 0x80l -> i16x8_abs
   | 0x81l -> i16x8_neg
+  | 0x82l -> i16x8_any_true
+  | 0x83l -> i16x8_all_true
   | 0x8el -> i16x8_add
   | 0x91l -> i16x8_sub
   | 0x95l -> i16x8_mul
@@ -292,6 +296,8 @@ let simd_prefix s =
   | 0x9bl -> i16x8_avgr_u
   | 0xa0l -> i32x4_abs
   | 0xa1l -> i32x4_neg
+  | 0xa2l -> i32x4_any_true
+  | 0xa3l -> i32x4_all_true
   | 0xael -> i32x4_add
   | 0xb1l -> i32x4_sub
   | 0xb5l -> i32x4_mul

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -227,6 +227,12 @@ let encode m =
       | Test (I64 I64Op.Eqz) -> op 0x50
       | Test (F32 _) -> assert false
       | Test (F64 _) -> assert false
+      | Test (V128 V128Op.(I8x16 AnyTrue)) -> simd_op 0x62l
+      | Test (V128 V128Op.(I8x16 AllTrue)) -> simd_op 0x63l
+      | Test (V128 V128Op.(I16x8 AnyTrue)) -> simd_op 0x82l
+      | Test (V128 V128Op.(I16x8 AllTrue)) -> simd_op 0x83l
+      | Test (V128 V128Op.(I32x4 AnyTrue)) -> simd_op 0xa2l
+      | Test (V128 V128Op.(I32x4 AllTrue)) -> simd_op 0xa3l
       | Test (V128 _) -> assert false
 
       | Compare (I32 I32Op.Eq) -> op 0x46

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -189,7 +189,14 @@ module SimdOp =
 struct
   open Ast.SimdOp
 
-  let testop xx = fun _ -> failwith "TODO v128"
+  let testop xx = function
+    | I8x16 AnyTrue -> "i8x16.any_true"
+    | I8x16 AllTrue -> "i8x16.all_true"
+    | I16x8 AnyTrue -> "i16x8.any_true"
+    | I16x8 AllTrue -> "i16x8.all_true"
+    | I32x4 AnyTrue -> "i32x4.any_true"
+    | I32x4 AllTrue -> "i32x4.all_true"
+    | _ -> assert false
 
   let relop xx = fun _ -> failwith "TODO v128"
 


### PR DESCRIPTION
This is sufficient to pass simd_boolean.wast.