### PR TITLE
Implement binary<->text support for SIMD store and extracts

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -222,7 +222,17 @@ let simd_prefix s =
   let pos = pos s in
   match vu32 s with
   | 0x00l -> let a, o = memop s in v128_load a o
+  | 0x0bl -> let a, o = memop s in v128_store a o
   | 0x0cl -> v128_const (at v128 s)
+  | 0x0el -> v8x16_swizzle
+  | 0x15l -> let imm = u8 s in i8x16_extract_lane_s imm
+  | 0x16l -> let imm = u8 s in i8x16_extract_lane_u imm
+  | 0x18l -> let imm = u8 s in i16x8_extract_lane_s imm
+  | 0x19l -> let imm = u8 s in i16x8_extract_lane_u imm
+  | 0x1bl -> let imm = u8 s in i32x4_extract_lane imm
+  | 0x1dl -> let imm = u8 s in i64x2_extract_lane imm
+  | 0x1fl -> let imm = u8 s in f32x4_extract_lane imm
+  | 0x21l -> let imm = u8 s in f64x2_extract_lane imm
   | 0x23l -> i8x16_eq
   | 0x24l -> i8x16_ne
   | 0x25l -> i8x16_lt_s
@@ -275,6 +285,7 @@ let simd_prefix s =
   | 0x61l -> i8x16_neg
   | 0x62l -> i8x16_any_true
   | 0x63l -> i8x16_all_true
+  | 0x6bl -> i8x16_shl
   | 0x6el -> i8x16_add
   | 0x71l -> i8x16_sub
   | 0x76l -> i8x16_min_s
@@ -327,6 +338,10 @@ let simd_prefix s =
   | 0xf3l -> f64x2_div
   | 0xf4l -> f64x2_min
   | 0xf5l -> f64x2_max
+  | 0xf8l -> i32x4_trunc_sat_f32x4_s
+  | 0xf9l -> i32x4_trunc_sat_f32x4_u
+  | 0xfal -> f32x4_convert_i32x4_s
+  | 0xfbl -> f32x4_convert_i32x4_u
   | n -> illegal s pos (I32.to_int_u n)
 
 let rec instr s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -316,6 +316,10 @@ let encode m =
       | Unary (V128 V128Op.(F64x2 Abs)) -> simd_op 0xecl
       | Unary (V128 V128Op.(F64x2 Neg)) -> simd_op 0xedl
       | Unary (V128 V128Op.(F64x2 Sqrt)) -> simd_op 0xefl
+      | Unary (V128 V128Op.(I32x4 TruncSatF32x4S)) -> simd_op 0xf8l
+      | Unary (V128 V128Op.(I32x4 TruncSatF32x4U)) -> simd_op 0xf9l
+      | Unary (V128 V128Op.(F32x4 ConvertI32x4S)) -> simd_op 0xfal
+      | Unary (V128 V128Op.(F32x4 ConvertI32x4U)) -> simd_op 0xfbl
       | Unary (V128 _) -> failwith "unimplemented V128 Unary op"
 
       | Binary (I32 I32Op.Add) -> op 0x6a
@@ -366,6 +370,7 @@ let encode m =
       | Binary (F64 F64Op.Max) -> op 0xa5
       | Binary (F64 F64Op.CopySign) -> op 0xa6
 
+      | Binary (V128 V128Op.(I8x16 Swizzle)) -> simd_op 0x0el
       | Binary (V128 V128Op.(I8x16 Eq)) -> simd_op 0x23l
       | Binary (V128 V128Op.(I8x16 Ne)) -> simd_op 0x24l
       | Binary (V128 V128Op.(I8x16 LtS)) -> simd_op 0x25l
@@ -495,13 +500,22 @@ let encode m =
       | Convert (F64 F64Op.PromoteF32) -> op 0xbb
       | Convert (F64 F64Op.DemoteF64) -> assert false
       | Convert (F64 F64Op.ReinterpretInt) -> op 0xbf
-      | Convert (V128 _) -> failwith "TODO v128"
+      | Convert (V128 _) -> failwith "TODO v128 convert"
 
-      | SimdExtract _ -> failwith "TODO v128"
+      | SimdExtract (V128Op.I8x16 (SX, imm)) -> simd_op 0x15l; u8 imm
+      | SimdExtract (V128Op.I8x16 (ZX, imm)) -> simd_op 0x16l; u8 imm
+      | SimdExtract (V128Op.I16x8 (SX, imm)) -> simd_op 0x18l; u8 imm
+      | SimdExtract (V128Op.I16x8 (ZX, imm)) -> simd_op 0x19l; u8 imm
+      | SimdExtract (V128Op.I32x4 (ZX, imm)) -> simd_op 0x1bl; u8 imm
+      | SimdExtract (V128Op.I64x2 (ZX, imm)) -> simd_op 0x1dl; u8 imm
+      | SimdExtract (V128Op.F32x4 (ZX, imm)) -> simd_op 0x1fl; u8 imm
+      | SimdExtract (V128Op.F64x2 (ZX, imm)) -> simd_op 0x21l; u8 imm
+      | SimdExtract _ -> assert false
 
-      | SimdReplace _ -> failwith "TODO v128"
+      | SimdReplace _ -> failwith "TODO v128 replace "
 
-      | SimdShift (_) -> failwith "TODO v128"
+      | SimdShift (V128Op.(I8x16 Shl)) -> simd_op 0x6bl
+      | SimdShift (_) -> failwith "TODO v128 shift"
 
     let const c =
       list instr c.it; end_ ()

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -207,10 +207,14 @@ struct
     | I16x8 Neg -> "i16x8.neg"
     | I32x4 Abs -> "i32x4.abs"
     | I32x4 Neg -> "i32x4.neg"
+    | I32x4 TruncSatF32x4S -> "i32x4.trunc_sat_f32x4_s"
+    | I32x4 TruncSatF32x4U -> "i32x4.trunc_sat_f32x4_u"
     | I64x2 Neg -> "i64x2.neg"
     | F32x4 Abs -> "f32x4.abs"
     | F32x4 Neg -> "f32x4.neg"
     | F32x4 Sqrt -> "f32x4.sqrt"
+    | F32x4 ConvertI32x4S -> "f32x4.convert_i32x4_s"
+    | F32x4 ConvertI32x4U -> "f32x4.convert_i32x4_u"
     | F64x2 Abs -> "f64x2.abs"
     | F64x2 Neg -> "f64x2.neg"
     | F64x2 Sqrt -> "f64x2.sqrt"
@@ -218,6 +222,7 @@ struct
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
+    | I8x16 Swizzle -> "v8x16.swizzle"
     | I8x16 Eq -> "i8x16.eq"
     | I8x16 Ne -> "i8x16.ne"
     | I8x16 LtS -> "i8x16.lt_s"
@@ -307,6 +312,22 @@ struct
     | Bitselect -> "v128.bitselect"
 
   let cvtop xx = fun _ -> failwith "TODO v128"
+
+  let extractop = function
+    | I8x16 (SX, imm) -> "i8x16.extract_lane_s " ^ (nat imm)
+    | I8x16 (ZX, imm) -> "i8x16.extract_lane_u " ^ (nat imm)
+    | I16x8 (SX, imm) -> "i16x8.extract_lane_s " ^ (nat imm)
+    | I16x8 (ZX, imm) -> "i16x8.extract_lane_u " ^ (nat imm)
+    | I32x4 (ZX, imm) -> "i32x4.extract_lane " ^ (nat imm)
+    | I64x2 (ZX, imm) -> "i64x2.extract_lane " ^ (nat imm)
+    | F32x4 (ZX, imm) -> "f32x4.extract_lane " ^ (nat imm)
+    | F64x2 (ZX, imm) -> "f64x2.extract_lane " ^ (nat imm)
+    | _ -> assert false
+
+  let shiftop = function
+    | I8x16 Shl -> "i8x16.shl"
+    | _ -> assert false
+
 end
 
 let oper (intop, floatop, simdop) op =
@@ -398,9 +419,9 @@ let rec instr e =
     | Binary op -> binop op, []
     | Ternary op -> ternop op, []
     | Convert op -> cvtop op, []
-    | SimdExtract op -> failwith "TODO v128"
+    | SimdExtract op -> SimdOp.extractop op, []
     | SimdReplace op -> failwith "TODO v128"
-    | SimdShift op -> failwith "TODO v128"
+    | SimdShift op -> SimdOp.shiftop op, []
   in Node (head, inner)
 
 let const c =


### PR DESCRIPTION
This is sufficient to pass simd_load.wast and simd_store.wast. There are
some extra instructions, like swizzle and i8x16.shl that is implemented
here, because simd_load.wast uses them.