### PR TITLE
Implement binary<->text support for SIMD splat and replace

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -224,15 +224,28 @@ let simd_prefix s =
   | 0x00l -> let a, o = memop s in v128_load a o
   | 0x0bl -> let a, o = memop s in v128_store a o
   | 0x0cl -> v128_const (at v128 s)
+  | 0x0dl -> v8x16_shuffle (List.init 16 (fun x -> u8 s))
   | 0x0el -> v8x16_swizzle
+  | 0x0fl -> i8x16_splat
+  | 0x10l -> i16x8_splat
+  | 0x11l -> i32x4_splat
+  | 0x12l -> i64x2_splat
+  | 0x13l -> f32x4_splat
+  | 0x14l -> f64x2_splat
   | 0x15l -> let imm = u8 s in i8x16_extract_lane_s imm
   | 0x16l -> let imm = u8 s in i8x16_extract_lane_u imm
+  | 0x17l -> let imm = u8 s in i8x16_replace_lane imm
   | 0x18l -> let imm = u8 s in i16x8_extract_lane_s imm
   | 0x19l -> let imm = u8 s in i16x8_extract_lane_u imm
+  | 0x1al -> let imm = u8 s in i16x8_replace_lane imm
   | 0x1bl -> let imm = u8 s in i32x4_extract_lane imm
+  | 0x1cl -> let imm = u8 s in i32x4_replace_lane imm
   | 0x1dl -> let imm = u8 s in i64x2_extract_lane imm
+  | 0x1el -> let imm = u8 s in i64x2_replace_lane imm
   | 0x1fl -> let imm = u8 s in f32x4_extract_lane imm
+  | 0x20l -> let imm = u8 s in f32x4_replace_lane imm
   | 0x21l -> let imm = u8 s in f64x2_extract_lane imm
+  | 0x22l -> let imm = u8 s in f64x2_replace_lane imm
   | 0x23l -> i8x16_eq
   | 0x24l -> i8x16_ne
   | 0x25l -> i8x16_lt_s

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -370,6 +370,7 @@ let encode m =
       | Binary (F64 F64Op.Max) -> op 0xa5
       | Binary (F64 F64Op.CopySign) -> op 0xa6
 
+      | Binary (V128 V128Op.(I8x16 (Shuffle imms))) -> simd_op 0x0dl; List.iter u8 imms
       | Binary (V128 V128Op.(I8x16 Swizzle)) -> simd_op 0x0el
       | Binary (V128 V128Op.(I8x16 Eq)) -> simd_op 0x23l
       | Binary (V128 V128Op.(I8x16 Ne)) -> simd_op 0x24l
@@ -500,7 +501,14 @@ let encode m =
       | Convert (F64 F64Op.PromoteF32) -> op 0xbb
       | Convert (F64 F64Op.DemoteF64) -> assert false
       | Convert (F64 F64Op.ReinterpretInt) -> op 0xbf
-      | Convert (V128 _) -> failwith "TODO v128 convert"
+
+      | Convert (V128 (V128Op.I8x16 V128Op.Splat)) -> simd_op 0x0fl;
+      | Convert (V128 (V128Op.I16x8 V128Op.Splat)) -> simd_op 0x10l;
+      | Convert (V128 (V128Op.I32x4 V128Op.Splat)) -> simd_op 0x11l;
+      | Convert (V128 (V128Op.I64x2 V128Op.Splat)) -> simd_op 0x12l;
+      | Convert (V128 (V128Op.F32x4 V128Op.Splat)) -> simd_op 0x13l;
+      | Convert (V128 (V128Op.F64x2 V128Op.Splat)) -> simd_op 0x14l;
+      | Convert (V128 _) -> assert false
 
       | SimdExtract (V128Op.I8x16 (SX, imm)) -> simd_op 0x15l; u8 imm
       | SimdExtract (V128Op.I8x16 (ZX, imm)) -> simd_op 0x16l; u8 imm
@@ -512,7 +520,13 @@ let encode m =
       | SimdExtract (V128Op.F64x2 (ZX, imm)) -> simd_op 0x21l; u8 imm
       | SimdExtract _ -> assert false
 
-      | SimdReplace _ -> failwith "TODO v128 replace "
+      | SimdReplace (V128Op.I8x16 imm) -> simd_op 0x17l; u8 imm
+      | SimdReplace (V128Op.I16x8 imm) -> simd_op 0x1al; u8 imm
+      | SimdReplace (V128Op.I32x4 imm) -> simd_op 0x1cl; u8 imm
+      | SimdReplace (V128Op.I64x2 imm) -> simd_op 0x1el; u8 imm
+      | SimdReplace (V128Op.F32x4 imm) -> simd_op 0x20l; u8 imm
+      | SimdReplace (V128Op.F64x2 imm) -> simd_op 0x22l; u8 imm
+      | SimdReplace _ -> assert false
 
       | SimdShift (V128Op.(I8x16 Shl)) -> simd_op 0x6bl
       | SimdShift (_) -> failwith "TODO v128 shift"

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -222,6 +222,7 @@ struct
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
+    | I8x16 (Shuffle imms) -> "v8x16.shuffle " ^ (String.concat " " (List.map nat imms))
     | I8x16 Swizzle -> "v8x16.swizzle"
     | I8x16 Eq -> "i8x16.eq"
     | I8x16 Ne -> "i8x16.ne"
@@ -311,7 +312,14 @@ struct
   let ternop (op : ternop) = match op with
     | Bitselect -> "v128.bitselect"
 
-  let cvtop xx = fun _ -> failwith "TODO v128"
+  let cvtop xx = function
+    | I8x16 Splat -> "i8x16.splat"
+    | I16x8 Splat -> "i16x8.splat"
+    | I32x4 Splat -> "i32x4.splat"
+    | I64x2 Splat -> "i64x2.splat"
+    | F32x4 Splat -> "f32x4.splat"
+    | F64x2 Splat -> "f64x2.splat"
+    | _ -> assert false
 
   let extractop = function
     | I8x16 (SX, imm) -> "i8x16.extract_lane_s " ^ (nat imm)
@@ -322,6 +330,15 @@ struct
     | I64x2 (ZX, imm) -> "i64x2.extract_lane " ^ (nat imm)
     | F32x4 (ZX, imm) -> "f32x4.extract_lane " ^ (nat imm)
     | F64x2 (ZX, imm) -> "f64x2.extract_lane " ^ (nat imm)
+    | _ -> assert false
+
+  let replaceop = function
+    | I8x16 imm -> "i8x16.replace_lane " ^ (nat imm)
+    | I16x8 imm -> "i16x8.replace_lane " ^ (nat imm)
+    | I32x4 imm -> "i32x4.replace_lane " ^ (nat imm)
+    | I64x2 imm -> "i64x2.replace_lane " ^ (nat imm)
+    | F32x4 imm -> "f32x4.replace_lane " ^ (nat imm)
+    | F64x2 imm -> "f64x2.replace_lane " ^ (nat imm)
     | _ -> assert false
 
   let shiftop = function
@@ -420,7 +437,7 @@ let rec instr e =
     | Ternary op -> ternop op, []
     | Convert op -> cvtop op, []
     | SimdExtract op -> SimdOp.extractop op, []
-    | SimdReplace op -> failwith "TODO v128"
+    | SimdReplace op -> SimdOp.replaceop op, []
     | SimdShift op -> SimdOp.shiftop op, []
   in Node (head, inner)
 


### PR DESCRIPTION
This is sufficient to pass simd_lane.wast.