### PR TITLE
Implement binary<->text support for SIMD saturating ops and some shifts

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -299,10 +299,15 @@ let simd_prefix s =
   | 0x62l -> i8x16_any_true
   | 0x63l -> i8x16_all_true
   | 0x6bl -> i8x16_shl
+  | 0x6cl -> i8x16_shr_s
   | 0x65l -> i8x16_narrow_i16x8_s
   | 0x66l -> i8x16_narrow_i16x8_u
   | 0x6el -> i8x16_add
+  | 0x6fl -> i8x16_add_saturate_s
+  | 0x70l -> i8x16_add_saturate_u
   | 0x71l -> i8x16_sub
+  | 0x72l -> i8x16_sub_saturate_s
+  | 0x73l -> i8x16_sub_saturate_u
   | 0x76l -> i8x16_min_s
   | 0x77l -> i8x16_min_u
   | 0x78l -> i8x16_max_s
@@ -318,8 +323,14 @@ let simd_prefix s =
   | 0x88l -> i16x8_widen_high_i8x16_s
   | 0x89l -> i16x8_widen_low_i8x16_u
   | 0x8al -> i16x8_widen_high_i8x16_u
+  | 0x8bl -> i16x8_shl
+  | 0x8cl -> i16x8_shr_s
   | 0x8el -> i16x8_add
+  | 0x8fl -> i16x8_add_saturate_s
+  | 0x90l -> i16x8_add_saturate_u
   | 0x91l -> i16x8_sub
+  | 0x92l -> i16x8_sub_saturate_s
+  | 0x93l -> i16x8_sub_saturate_u
   | 0x95l -> i16x8_mul
   | 0x96l -> i16x8_min_s
   | 0x97l -> i16x8_min_u
@@ -334,6 +345,8 @@ let simd_prefix s =
   | 0xa8l -> i32x4_widen_high_i16x8_s
   | 0xa9l -> i32x4_widen_low_i16x8_u
   | 0xaal -> i32x4_widen_high_i16x8_u
+  | 0xabl -> i32x4_shl
+  | 0xacl -> i32x4_shr_s
   | 0xael -> i32x4_add
   | 0xb1l -> i32x4_sub
   | 0xb5l -> i32x4_mul
@@ -342,6 +355,8 @@ let simd_prefix s =
   | 0xb8l -> i32x4_max_s
   | 0xb9l -> i32x4_max_u
   | 0xc1l -> i64x2_neg
+  | 0xcbl -> i64x2_shl
+  | 0xccl -> i64x2_shr_s
   | 0xcel -> i64x2_add
   | 0xd1l -> i64x2_sub
   | 0xd5l -> i64x2_mul

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -393,7 +393,11 @@ let encode m =
       | Binary (V128 V128Op.(I8x16 NarrowS)) -> simd_op 0x65l
       | Binary (V128 V128Op.(I8x16 NarrowU)) -> simd_op 0x66l
       | Binary (V128 V128Op.(I8x16 Add)) -> simd_op 0x6el
+      | Binary (V128 V128Op.(I8x16 AddSatS)) -> simd_op 0x6fl
+      | Binary (V128 V128Op.(I8x16 AddSatU)) -> simd_op 0x70l
       | Binary (V128 V128Op.(I8x16 Sub)) -> simd_op 0x71l
+      | Binary (V128 V128Op.(I8x16 SubSatS)) -> simd_op 0x72l
+      | Binary (V128 V128Op.(I8x16 SubSatU)) -> simd_op 0x73l
       | Binary (V128 V128Op.(I8x16 MinS)) -> simd_op 0x76l
       | Binary (V128 V128Op.(I8x16 MinU)) -> simd_op 0x77l
       | Binary (V128 V128Op.(I8x16 MaxS)) -> simd_op 0x78l
@@ -412,7 +416,11 @@ let encode m =
       | Binary (V128 V128Op.(I16x8 NarrowS)) -> simd_op 0x85l
       | Binary (V128 V128Op.(I16x8 NarrowU)) -> simd_op 0x86l
       | Binary (V128 V128Op.(I16x8 Add)) -> simd_op 0x8el
+      | Binary (V128 V128Op.(I16x8 AddSatS)) -> simd_op 0x8fl
+      | Binary (V128 V128Op.(I16x8 AddSatU)) -> simd_op 0x90l
       | Binary (V128 V128Op.(I16x8 Sub)) -> simd_op 0x91l
+      | Binary (V128 V128Op.(I16x8 SubSatS)) -> simd_op 0x92l
+      | Binary (V128 V128Op.(I16x8 SubSatU)) -> simd_op 0x93l
       | Binary (V128 V128Op.(I16x8 Mul)) -> simd_op 0x95l
       | Binary (V128 V128Op.(I16x8 MinS)) -> simd_op 0x96l
       | Binary (V128 V128Op.(I16x8 MinU)) -> simd_op 0x97l
@@ -540,7 +548,12 @@ let encode m =
       | SimdReplace (V128Op.F64x2 imm) -> simd_op 0x22l; u8 imm
       | SimdReplace _ -> assert false
 
-      | SimdShift (V128Op.(I8x16 Shl)) -> simd_op 0x6bl
+      | SimdShift V128Op.(I8x16 Shl) -> simd_op 0x6bl
+      | SimdShift V128Op.(I8x16 ShrS) -> simd_op 0x6cl
+      | SimdShift V128Op.(I16x8 Shl) -> simd_op 0x8bl
+      | SimdShift V128Op.(I16x8 ShrS) -> simd_op 0x8cl
+      | SimdShift V128Op.(I32x4 Shl) -> simd_op 0xabl
+      | SimdShift V128Op.(I32x4 ShrS) -> simd_op 0xacl
       | SimdShift (_) -> failwith "TODO v128 shift"
 
     let const c =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -265,7 +265,11 @@ struct
     | I8x16 NarrowS -> "i8x16.narrow_i16x8_s"
     | I8x16 NarrowU -> "i8x16.narrow_i16x8_u"
     | I8x16 Add -> "i8x16.add"
+    | I8x16 AddSatS -> "i8x16.add_saturate_s"
+    | I8x16 AddSatU -> "i8x16.add_saturate_u"
     | I8x16 Sub -> "i8x16.sub"
+    | I8x16 SubSatS -> "i8x16.sub_saturate_s"
+    | I8x16 SubSatU -> "i8x16.sub_saturate_u"
     | I8x16 MinS -> "i8x16.min_s"
     | I8x16 MinU -> "i8x16.min_u"
     | I8x16 MaxS -> "i8x16.max_s"
@@ -274,7 +278,11 @@ struct
     | I16x8 NarrowS -> "i16x8.narrow_i32x4_s"
     | I16x8 NarrowU -> "i16x8.narrow_i32x4_u"
     | I16x8 Add -> "i16x8.add"
+    | I16x8 AddSatS -> "i16x8.add_saturate_s"
+    | I16x8 AddSatU -> "i16x8.add_saturate_u"
     | I16x8 Sub -> "i16x8.sub"
+    | I16x8 SubSatS -> "i16x8.sub_saturate_s"
+    | I16x8 SubSatU -> "i16x8.sub_saturate_u"
     | I16x8 Mul -> "i16x8.mul"
     | I16x8 MinS -> "i16x8.min_s"
     | I16x8 MinU -> "i16x8.min_u"
@@ -355,6 +363,11 @@ struct
 
   let shiftop = function
     | I8x16 Shl -> "i8x16.shl"
+    | I8x16 ShrS -> "i8x16.shr_s"
+    | I16x8 Shl -> "i16x8.shl"
+    | I16x8 ShrS -> "i16x8.shr_s"
+    | I32x4 Shl -> "i32x4.shl"
+    | I32x4 ShrS -> "i32x4.shr_s"
     | _ -> assert false
 
 end


### PR DESCRIPTION
This is sufficient to pass simd_splat.wast.