### PR TITLE
Rename shuffle and swizzle to i8x16 prefix

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -234,8 +234,8 @@ let simd_prefix s =
   | 0x0al -> let a, o = memop s in v64x2_load_splat a o
   | 0x0bl -> let a, o = memop s in v128_store a o
   | 0x0cl -> v128_const (at v128 s)
-  | 0x0dl -> v8x16_shuffle (List.init 16 (fun x -> u8 s))
-  | 0x0el -> v8x16_swizzle
+  | 0x0dl -> i8x16_shuffle (List.init 16 (fun x -> u8 s))
+  | 0x0el -> i8x16_swizzle
   | 0x0fl -> i8x16_splat
   | 0x10l -> i16x8_splat
   | 0x11l -> i32x4_splat

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -247,8 +247,8 @@ let v128_or = Binary (V128 (V128Op.V128 V128Op.Or))
 let v128_xor = Binary (V128 (V128Op.V128 V128Op.Xor))
 let v128_bitselect = Ternary (V128Op.Bitselect)
 
-let v8x16_swizzle = Binary (V128 V128Op.(I8x16 Swizzle))
-let v8x16_shuffle imms = Binary (V128 V128Op.(I8x16 (Shuffle imms)))
+let i8x16_swizzle = Binary (V128 V128Op.(I8x16 Swizzle))
+let i8x16_shuffle imms = Binary (V128 V128Op.(I8x16 (Shuffle imms)))
 
 let i8x16_splat = Convert (V128 (V128Op.I8x16 V128Op.Splat))
 let i8x16_extract_lane_s imm = SimdExtract (V128Op.I8x16 (SX, imm))

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -231,8 +231,8 @@ struct
     | _ -> failwith "Unimplemented v128 unop"
 
   let binop xx (op : binop) = match op with
-    | I8x16 (Shuffle imms) -> "v8x16.shuffle " ^ (String.concat " " (List.map nat imms))
-    | I8x16 Swizzle -> "v8x16.swizzle"
+    | I8x16 (Shuffle imms) -> "i8x16.shuffle " ^ (String.concat " " (List.map nat imms))
+    | I8x16 Swizzle -> "i8x16.swizzle"
     | I8x16 Eq -> "i8x16.eq"
     | I8x16 Ne -> "i8x16.ne"
     | I8x16 LtS -> "i8x16.lt_s"

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -479,8 +479,8 @@ rule token = parse
   | (simd_float_shape as s)".le" { BINARY (simd_float_op s f32x4_le f64x2_le) }
   | (simd_float_shape as s)".gt" { BINARY (simd_float_op s f32x4_gt f64x2_gt) }
   | (simd_float_shape as s)".ge" { BINARY (simd_float_op s f32x4_ge f64x2_ge) }
-  | "v8x16.swizzle" { BINARY v8x16_swizzle }
-  | "v8x16.shuffle" { SHUFFLE }
+  | "i8x16.swizzle" { BINARY i8x16_swizzle }
+  | "i8x16.shuffle" { SHUFFLE }
   | vxxx".not" { UNARY v128_not }
   | vxxx".and" { UNARY v128_and }
   | vxxx".andnot" { UNARY v128_andnot }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -400,7 +400,7 @@ plain_instr :
   | EXTRACT_LANE NAT { let at = at () in fun c -> $1 (simd_lane_index $2 at) }
   | REPLACE_LANE NAT { let at = at () in fun c -> $1 (simd_lane_index $2 at) }
   | SHIFT { fun c -> $1 }
-  | SHUFFLE literal_list { let at = at () in fun c -> v8x16_shuffle (shuffle_literal $2 at) }
+  | SHUFFLE literal_list { let at = at () in fun c -> i8x16_shuffle (shuffle_literal $2 at) }
 
 
 call_instr :

--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -24,7 +24,7 @@ instr ::= ...
 
 Some SIMD instructions have additional immediate operands following `simdop`.
 These immediate operands are encoded as individual bytes.
-For example, the `v8x16.shuffle` instruction has 16 bytes after `simdop`.
+For example, the `i8x16.shuffle` instruction has 16 bytes after `simdop`.
 
 In the description below, `ImmLaneIdx{I}` indicates the maximum value of the byte.
 For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
@@ -45,8 +45,8 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `v64x2.load_splat`         |    `0x0a`| m:memarg           |
 | `v128.store`               |    `0x0b`| m:memarg           |
 | `v128.const`               |    `0x0c`| i:ImmByte[16]      |
-| `v8x16.shuffle`            |    `0x0d`| s:ImmLaneIdx32[16] |
-| `v8x16.swizzle`            |    `0x0e`| -                  |
+| `i8x16.shuffle`            |    `0x0d`| s:ImmLaneIdx32[16] |
+| `i8x16.swizzle`            |    `0x0e`| -                  |
 | `i8x16.splat`              |    `0x0f`| -                  |
 | `i16x8.splat`              |    `0x10`| -                  |
 | `i32x4.splat`              |    `0x11`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -13,8 +13,8 @@
 | `v64x2.load_splat`         |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `v128.store`               |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `v128.const`               | `-munimplemented-simd128` | :heavy_check_mark: [6] |                    |                    | :heavy_check_mark: |
-| `v8x16.shuffle`            |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `v8x16.swizzle`            |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i8x16.shuffle`            |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i8x16.swizzle`            |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.splat`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.splat`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.splat`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -16,8 +16,8 @@
 | Basic operation | opcode |
 | ----------------| ------ |
 | v128.const      | 0x0c   |
-| v8x16.shuffle   | 0x0d   |
-| v8x16.swizzle   | 0x0e   |
+| i8x16.shuffle   | 0x0d   |
+| i8x16.swizzle   | 0x0e   |
 
 | Splat operation | opcode |
 | --------------- | ------ |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -300,7 +300,7 @@ The input lane value, `x`, is interpreted the same way as for the splat
 instructions. For the `i8` and `i16` lanes, the high bits of `x` are ignored.
 
 ### Shuffling using immediate indices
-* `v8x16.shuffle(a: v128, b: v128, imm: ImmLaneIdx32[16]) -> v128`
+* `i8x16.shuffle(a: v128, b: v128, imm: ImmLaneIdx32[16]) -> v128`
 
 Returns a new vector with lanes selected from the lanes of the two input vectors
 `a` and `b` specified in the 16 byte wide immediate mode operand `imm`. This
@@ -320,7 +320,7 @@ def S.shuffle(a, b, s):
 ```
 
 ### Swizzling using variable indices
-* `v8x16.swizzle(a: v128, s: v128) -> v128`
+* `i8x16.swizzle(a: v128, s: v128) -> v128`
 
 Returns a new vector with lanes selected from the lanes of the first input
 vector `a` specified in the second input vector `s`. The indices `i` in range

--- a/proposals/simd/TextSIMD.md
+++ b/proposals/simd/TextSIMD.md
@@ -20,8 +20,8 @@ The canonical text format used for printing `v128.const` instructions is
 v128.const i32x4 0xNNNNNNNN 0xNNNNNNNN 0xNNNNNNNN 0xNNNNNNNN
 ```
 
-### v8x16.shuffle
+### i8x16.shuffle
 
 ```
-v8x16.shuffle i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5
+i8x16.shuffle i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5 i5
 ```

--- a/test/core/simd/simd_lane.wast
+++ b/test/core/simd/simd_lane.wast
@@ -61,21 +61,21 @@
 
   ;; Swizzle and shuffle
   (func (export "v8x16_swizzle") (param v128 v128) (result v128)
-    (v8x16.swizzle (local.get 0) (local.get 1)))
+    (i8x16.swizzle (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-1") (param v128 v128) (result v128)
-    (v8x16.shuffle  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 (local.get 0) (local.get 1)))
+    (i8x16.shuffle  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-2") (param v128 v128) (result v128)
-    (v8x16.shuffle 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 (local.get 0) (local.get 1)))
+    (i8x16.shuffle 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-3") (param v128 v128) (result v128)
-    (v8x16.shuffle 31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 (local.get 0) (local.get 1)))
+    (i8x16.shuffle 31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-4") (param v128 v128) (result v128)
-    (v8x16.shuffle 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 (local.get 0) (local.get 1)))
+    (i8x16.shuffle 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-5") (param v128 v128) (result v128)
-    (v8x16.shuffle  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 (local.get 0) (local.get 1)))
+    (i8x16.shuffle  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-6") (param v128 v128) (result v128)
-    (v8x16.shuffle 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 (local.get 0) (local.get 1)))
+    (i8x16.shuffle 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 (local.get 0) (local.get 1)))
   (func (export "v8x16_shuffle-7") (param v128 v128) (result v128)
-    (v8x16.shuffle  0  0  0  0  0  0  0  0 16 16 16 16 16 16 16 16 (local.get 0) (local.get 1)))
+    (i8x16.shuffle  0  0  0  0  0  0  0  0 16 16 16 16 16 16 16 16 (local.get 0) (local.get 1)))
 )
 
 (assert_return (invoke "i8x16_extract_lane_s-first" (v128.const i8x16 127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)) (i32.const 127))
@@ -501,33 +501,33 @@
 
 ;; Invalid types for swizzle and shuffle values
 (assert_invalid (module (func (result v128)
-  (v8x16.swizzle (i32.const 1) (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))) "type mismatch")
+  (i8x16.swizzle (i32.const 1) (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))) "type mismatch")
 (assert_invalid (module (func (result v128)
-  (v8x16.swizzle (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) (i32.const 2)))) "type mismatch")
+  (i8x16.swizzle (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) (i32.const 2)))) "type mismatch")
 (assert_invalid (module (func (result v128)
-  (v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (f32.const 3.0)
+  (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (f32.const 3.0)
   (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))) "type mismatch")
 (assert_invalid (module (func (result v128)
-  (v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+  (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
   (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) (f32.const 4.0)))) "type mismatch")
 
-;; v8x16.shuffle: the 1st argument must be 16-byte literals in 0..32
+;; i8x16.shuffle: the 1st argument must be 16-byte literals in 0..32
 (assert_malformed (module quote "(func (param v128) (result v128)"
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 (local.get 0) (local.get 0)))")
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 (local.get 0) (local.get 0)))")
   "invalid lane length")
 (assert_malformed (module quote "(func (param v128) (result v128)"
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 (local.get 0) (local.get 0)))")
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 (local.get 0) (local.get 0)))")
   "invalid lane length")
 (assert_malformed (module quote "(func (result v128)"
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 -1"
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 -1"
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)"
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_malformed (module quote "(func (result v128)"
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 256"
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 256"
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)"
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_invalid (module (func (result v128)
-  (v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 255
+  (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 255
   (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)
   (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))) "invalid lane index")
 
@@ -543,21 +543,21 @@
 
 ;; Old shuffle instruction names will not work
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle1 (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
+  "(i8x16.shuffle1 (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))")
   "unknown operator")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle2_imm  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 "
+  "(i8x16.shuffle2_imm  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31)))")
   "unknown operator")
-;; v8x16 not i8x16
+;; i8x16 not v8x16
 (assert_malformed (module quote "(func (result v128) "
-  "(i8x16.swizzle (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
+  "(v8x16.swizzle (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))")
   "unknown operator")
 (assert_malformed (module quote "(func (result v128) "
-  "(i8x16.shuffle  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 "
+  "(v8x16.shuffle  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31)))")
   "unknown operator")
@@ -596,29 +596,29 @@
 (assert_malformed (module quote "(func (result v128) (i32x4.replace_lane inf (v128.const i32x4 0 0 0 0) (i32.const 1)))") "unexpected token")
 (assert_malformed (module quote "(func (result v128) (f32x4.replace_lane -inf (v128.const f32x4 0 0 0 0) (f32.const 1.1)))") "unexpected token")
 
-;; v8x16.shuffle expects a 16-byte literals as first argument
+;; i8x16.shuffle expects a 16-byte literals as first argument
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle (v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31) "
+  "(i8x16.shuffle (v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "invalid lane length")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15.0) "
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15.0) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle 0.5 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
+  "(i8x16.shuffle 0.5 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle -inf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
+  "(i8x16.shuffle -inf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 inf) "
+  "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 inf) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 (assert_malformed (module quote "(func (result v128) "
-  "(v8x16.shuffle nan 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
+  "(i8x16.shuffle nan 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) "
   "(v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) "
   "(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))") "malformed lane index")
 
@@ -664,9 +664,9 @@
 
   ;; i8x16.replace outputs as shuffle operand
   (func (export "as-v8x16_swizzle-operand") (param v128 i32 v128) (result v128)
-    (v8x16.swizzle (i8x16.replace_lane 0 (local.get 0) (local.get 1)) (local.get 2)))
+    (i8x16.swizzle (i8x16.replace_lane 0 (local.get 0) (local.get 1)) (local.get 2)))
   (func (export "as-v8x16_shuffle-operands") (param v128 i32 v128 i32) (result v128)
-    (v8x16.shuffle 16 1 18 3 20 5 22 7 24 9 26 11 28 13 30 15
+    (i8x16.shuffle 16 1 18 3 20 5 22 7 24 9 26 11 28 13 30 15
       (i8x16.replace_lane 0 (local.get 0) (local.get 1))
       (i8x16.replace_lane 15 (local.get 2) (local.get 3))))
 )
@@ -726,10 +726,10 @@
     (i64x2.add (i64x2.replace_lane 0 (local.get 0) (local.get 1)) (i64x2.replace_lane 1 (local.get 2) (local.get 3))))
 
   (func (export "swizzle-as-i8x16_add-operands") (param v128 v128 v128 v128) (result v128)
-    (i8x16.add (v8x16.swizzle (local.get 0) (local.get 1)) (v8x16.swizzle (local.get 2) (local.get 3))))
+    (i8x16.add (i8x16.swizzle (local.get 0) (local.get 1)) (i8x16.swizzle (local.get 2) (local.get 3))))
   (func (export "shuffle-as-i8x16_sub-operands") (param v128 v128 v128 v128) (result v128)
-    (i8x16.sub (v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (local.get 0) (local.get 1))
-      (v8x16.shuffle 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 (local.get 2) (local.get 3))))
+    (i8x16.sub (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (local.get 0) (local.get 1))
+      (i8x16.shuffle 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 (local.get 2) (local.get 3))))
 
   ;; Boolean horizontal reductions
   (func (export "as-i8x16_any_true-operand") (param v128 i32) (result i32)
@@ -742,9 +742,9 @@
     (i32x4.any_true (i64x2.replace_lane 0 (local.get 0) (local.get 1))))
 
   (func (export "swizzle-as-i8x16_all_true-operands") (param v128 v128) (result i32)
-    (i8x16.all_true (v8x16.swizzle (local.get 0) (local.get 1))))
+    (i8x16.all_true (i8x16.swizzle (local.get 0) (local.get 1))))
   (func (export "shuffle-as-i8x16_any_true-operands") (param v128 v128) (result i32)
-    (i8x16.any_true (v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (local.get 0) (local.get 1))))
+    (i8x16.any_true (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (local.get 0) (local.get 1))))
 )
 
 (assert_return (invoke "as-i8x16_splat-operand" (v128.const i8x16 0xff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)) (v128.const i8x16 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1))
@@ -842,9 +842,9 @@
     (return (global.get $g)))
 
    (func (export "as-return-value-2") (param v128 v128) (result v128)
-    (return (v8x16.swizzle (local.get 0) (local.get 1))))
+    (return (i8x16.swizzle (local.get 0) (local.get 1))))
   (func (export "as-global_set-value-2") (param v128 v128) (result v128)
-    (global.set $h (v8x16.shuffle 0 1 2 3 4 5 6 7 24 25 26 27 28 29 30 31 (local.get 0) (local.get 1)))
+    (global.set $h (i8x16.shuffle 0 1 2 3 4 5 6 7 24 25 26 27 28 29 30 31 (local.get 0) (local.get 1)))
     (return (global.get $h)))
 
   (func (export "as-local_set-value-1") (param v128) (result i64) (local i64)
@@ -1236,8 +1236,8 @@
 )
 (assert_malformed
   (module quote
-    "(func $v8x16.shuffle-1st-arg-empty (result v128)"
-    "  (v8x16.shuffle"
+    "(func $i8x16.shuffle-1st-arg-empty (result v128)"
+    "  (i8x16.shuffle"
     "    (v128.const i8x16 0 1 2 3 5 6 6 7 8 9 10 11 12 13 14 15)"
     "    (v128.const i8x16 1 2 3 5 6 6 7 8 9 10 11 12 13 14 15 16)"
     "  )"
@@ -1247,8 +1247,8 @@
 )
 (assert_invalid
   (module
-    (func $v8x16.shuffle-2nd-arg-empty (result v128)
-      (v8x16.shuffle 0 1 2 3 5 6 6 7 8 9 10 11 12 13 14 15
+    (func $i8x16.shuffle-2nd-arg-empty (result v128)
+      (i8x16.shuffle 0 1 2 3 5 6 6 7 8 9 10 11 12 13 14 15
         (v128.const i8x16 1 2 3 5 6 6 7 8 9 10 11 12 13 14 15 16)
       )
     )
@@ -1257,8 +1257,8 @@
 )
 (assert_malformed
   (module quote
-    "(func $v8x16.shuffle-arg-empty (result v128)"
-    "  (v8x16.shuffle)"
+    "(func $i8x16.shuffle-arg-empty (result v128)"
+    "  (i8x16.shuffle)"
     ")"
   )
   "invalid lane length"

--- a/test/core/simd/simd_load.wast
+++ b/test/core/simd/simd_load.wast
@@ -120,11 +120,11 @@
 (module (memory 1)
   (data (offset (i32.const 0)) "\64\65\66\67\68\69\6a\6b\6c\6d\6e\6f\70\71\72\73")  ;; 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115
   (data (offset (i32.const 16)) "\0f\0e\0d\0c\0b\0a\09\08\07\06\05\04\03\02\01\00")  ;;  15  14  13  12  11  10  09  08  07  06  05  04  03  02  01  00
-  (func (export "as-v8x16.swizzle-operand") (result v128)
-    (v8x16.swizzle (v128.load (i32.const 0)) (v128.load offset=15 (i32.const 1)))
+  (func (export "as-i8x16.swizzle-operand") (result v128)
+    (i8x16.swizzle (v128.load (i32.const 0)) (v128.load offset=15 (i32.const 1)))
   )
 )
-(assert_return(invoke "as-v8x16.swizzle-operand") (v128.const i8x16 115 114 113 112 111 110 109 108 107 106 105 104 103 102 101 100))
+(assert_return(invoke "as-i8x16.swizzle-operand") (v128.const i8x16 115 114 113 112 111 110 109 108 107 106 105 104 103 102 101 100))
 
 (module (memory 1)
   (data (i32.const 0) "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\00\01\02\03")

--- a/test/core/simd/simd_splat.wast
+++ b/test/core/simd/simd_splat.wast
@@ -188,7 +188,7 @@
   (func (export "as-f32x4_extract_lane_s-operand-last") (param f32) (result f32)
     (f32x4.extract_lane 3 (f32x4.splat (local.get 0))))
   (func (export "as-v8x16_swizzle-operands") (param i32) (param i32) (result v128)
-    (v8x16.swizzle (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+    (i8x16.swizzle (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
   (func (export "as-i64x2_extract_lane-operand-first") (param i64) (result i64)
     (i64x2.extract_lane 0 (i64x2.splat (local.get 0))))
   (func (export "as-i64x2_extract_lane-operand-last") (param i64) (result i64)


### PR DESCRIPTION
v8x16.shuffle and v8x16.swizzle is now i8x16.shuffle and i8x16.swizzle
respectively.

Fixed #316.