### PR TITLE
Run SIMD tests

### DIFF
--- a/test/core/run.py
+++ b/test/core/run.py
@@ -22,14 +22,14 @@ parser.add_argument("file", nargs='*')
 arguments = parser.parse_args()
 sys.argv = sys.argv[:1]
 
-mvp_test_files = glob.glob(os.path.join(inputDir, "*.wast"))
+main_test_files = glob.glob(os.path.join(inputDir, "*.wast"))
 # SIMD test files are in a subdirectory.
 simd_test_files = glob.glob(os.path.join(inputDir, "simd", "*.wast"))
 
 wasmCommand = arguments.wasm
 jsCommand = arguments.js
 outputDir = arguments.out
-inputFiles = arguments.file if arguments.file else mvp_test_files + simd_test_files
+inputFiles = arguments.file if arguments.file else main_test_files + simd_test_files
 
 if not os.path.exists(wasmCommand):
   sys.stderr.write("""\

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -22,10 +22,14 @@ parser.add_argument("file", nargs='*')
 arguments = parser.parse_args()
 sys.argv = sys.argv[:1]
 
+mvp_test_files = glob.glob(os.path.join(inputDir, "*.wast"))
+# SIMD test files are in a subdirectory.
+simd_test_files = glob.glob(os.path.join(inputDir, "simd", "*.wast"))
+
 wasmCommand = arguments.wasm
 jsCommand = arguments.js
 outputDir = arguments.out
-inputFiles = arguments.file if arguments.file else glob.glob(os.path.join(inputDir, "*.wast"))
+inputFiles = arguments.file if arguments.file else mvp_test_files + simd_test_files
 
 if not os.path.exists(wasmCommand):
   sys.stderr.write("""\


### PR DESCRIPTION
This enables running all the SIMD tests (in test/core/simd) whenever we
do `make test`.

This should not be submitted yet, it depends on #306 or #307 for the
implementation of load splats and loads extends.