### PR TITLE
Implement binary<->text support for SIMD load splats and extends

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -222,6 +222,16 @@ let simd_prefix s =
   let pos = pos s in
   match vu32 s with
   | 0x00l -> let a, o = memop s in v128_load a o
+  | 0x01l -> let a, o = memop s in i16x8_load8x8_s a o
+  | 0x02l -> let a, o = memop s in i16x8_load8x8_u a o
+  | 0x03l -> let a, o = memop s in i32x4_load16x4_s a o
+  | 0x04l -> let a, o = memop s in i32x4_load16x4_u a o
+  | 0x05l -> let a, o = memop s in i64x2_load32x2_s a o
+  | 0x06l -> let a, o = memop s in i64x2_load32x2_u a o
+  | 0x07l -> let a, o = memop s in v8x16_load_splat a o
+  | 0x08l -> let a, o = memop s in v16x8_load_splat a o
+  | 0x09l -> let a, o = memop s in v32x4_load_splat a o
+  | 0x0al -> let a, o = memop s in v64x2_load_splat a o
   | 0x0bl -> let a, o = memop s in v128_store a o
   | 0x0cl -> v128_const (at v128 s)
   | 0x0dl -> v8x16_shuffle (List.init 16 (fun x -> u8 s))

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -197,8 +197,29 @@ let encode m =
         op 0x35; memop mo
       | Load {ty = F32Type | F64Type; sz = Some _; _} ->
         assert false
-      | Load ({ty = V128Type; _} as mo) ->
+
+      | SimdLoad ({ty = V128Type; sz = None; _} as mo) ->
         simd_op 0x00l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack8x8 SX); _} as mo) ->
+        simd_op 0x01l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack8x8 ZX); _} as mo) ->
+        simd_op 0x02l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack16x4 SX); _} as mo) ->
+        simd_op 0x03l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack16x4 ZX); _} as mo) ->
+        simd_op 0x04l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack32x2 SX); _} as mo) ->
+        simd_op 0x05l; memop mo
+      | SimdLoad ({ty = V128Type; sz = Some (Pack64, Pack32x2 ZX); _} as mo) ->
+        simd_op 0x06l; memop mo
+      | SimdLoad ({ty= V128Type; sz = Some (Pack8, PackSplat); _} as mo) ->
+        simd_op 0x07l; memop mo
+      | SimdLoad ({ty= V128Type; sz = Some (Pack16, PackSplat); _} as mo) ->
+        simd_op 0x08l; memop mo
+      | SimdLoad ({ty= V128Type; sz = Some (Pack32, PackSplat); _} as mo) ->
+        simd_op 0x09l; memop mo
+      | SimdLoad ({ty= V128Type; sz = Some (Pack64, PackSplat); _} as mo) ->
+        simd_op 0x0al; memop mo
 
       | Store ({ty = I32Type; sz = None; _} as mo) -> op 0x36; memop mo
       | Store ({ty = I64Type; sz = None; _} as mo) -> op 0x37; memop mo
@@ -211,8 +232,8 @@ let encode m =
       | Store ({ty = I64Type; sz = Some Pack16; _} as mo) -> op 0x3d; memop mo
       | Store ({ty = I64Type; sz = Some Pack32; _} as mo) -> op 0x3e; memop mo
       | Store {ty = F32Type | F64Type; sz = Some _; _} -> assert false
-      | Store ({ty = V128Type; _} as mo) ->
-        simd_op 0x0bl; memop mo
+
+      | SimdStore ({ty = V128Type; _} as mo) -> simd_op 0x0bl; memop mo
 
       | MemorySize -> op 0x3f; u8 0x00
       | MemoryGrow -> op 0x40; u8 0x00


### PR DESCRIPTION
The names are still pre #297, once that's finalize I can fix this up
(after the sync #323).

With this change, test/core/run.py passes on all test cases in simd/.