### PR TITLE
Fix SIMD bitmask

### DIFF
--- a/interpreter/exec/simd.ml
+++ b/interpreter/exec/simd.ml
@@ -310,7 +310,7 @@ struct
     let bitmask x =
       let xs = Convert.to_shape x in
       let negs = List.map (fun x -> if Int.(lt_s x zero) then Int32.one else Int32.zero) xs in
-      List.fold_left (fun a b -> Int32.(logor b (shift_left a 1))) Int32.zero negs
+      List.fold_right (fun a b -> Int32.(logor a (shift_left b 1))) negs Int32.zero
     let shl v s =
       let shift = Int.of_int_u (Int32.to_int s) in
       unop (fun a -> Int.shl a shift) v

--- a/test/core/simd/simd_boolean.wast
+++ b/test/core/simd/simd_boolean.wast
@@ -54,7 +54,7 @@
 (assert_return (invoke "i8x16.bitmask" (v128.const i8x16 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF))
                                         (i32.const 0x0000FFFF))
 (assert_return (invoke "i8x16.bitmask" (v128.const i8x16 -1 0 1 2 3 4 5 6 7 8 9 0xA 0xB 0xC 0xD 0xF))
-                                        (i32.const 0x00008000))
+                                        (i32.const 0x00000001))
 
 ;; i16x8
 (assert_return (invoke "i16x8.any_true" (v128.const i16x8 0 0 0 0 0 0 0 0))
@@ -104,7 +104,7 @@
 (assert_return (invoke "i16x8.bitmask" (v128.const i16x8 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF))
                                         (i32.const 0x000000FF))
 (assert_return (invoke "i16x8.bitmask" (v128.const i16x8 -1 0 1 2 0xB 0xC 0xD 0xF))
-                                        (i32.const 0x00000080))
+                                        (i32.const 0x00000001))
 
 ;; i32x4
 (assert_return (invoke "i32x4.any_true" (v128.const i32x4 0 0 0 0))
@@ -154,7 +154,7 @@
 (assert_return (invoke "i32x4.bitmask" (v128.const i32x4 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF))
                                         (i32.const 0x0000000F))
 (assert_return (invoke "i32x4.bitmask" (v128.const i32x4 -1 0 1 0xF))
-                                        (i32.const 0x00000008))
+                                        (i32.const 0x00000001))
 
 ;; Combination
 


### PR DESCRIPTION
Bitmask was confused about endianness. The text format for v128.const is
little endian, so the lowest lane set translates to the least
significant bit set.