### PR TITLE
Remove integer SIMD not-equals instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -68,7 +68,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `f64x2.extract_lane`       |    `0x21`| i:ImmLaneIdx2      |
 | `f64x2.replace_lane`       |    `0x22`| i:ImmLaneIdx2      |
 | `i8x16.eq`                 |    `0x23`| -                  |
-| `i8x16.ne`                 |    `0x24`| -                  |
 | `i8x16.lt_s`               |    `0x25`| -                  |
 | `i8x16.lt_u`               |    `0x26`| -                  |
 | `i8x16.gt_s`               |    `0x27`| -                  |
@@ -78,7 +77,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i8x16.ge_s`               |    `0x2b`| -                  |
 | `i8x16.ge_u`               |    `0x2c`| -                  |
 | `i16x8.eq`                 |    `0x2d`| -                  |
-| `i16x8.ne`                 |    `0x2e`| -                  |
 | `i16x8.lt_s`               |    `0x2f`| -                  |
 | `i16x8.lt_u`               |    `0x30`| -                  |
 | `i16x8.gt_s`               |    `0x31`| -                  |
@@ -88,7 +86,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i16x8.ge_s`               |    `0x35`| -                  |
 | `i16x8.ge_u`               |    `0x36`| -                  |
 | `i32x4.eq`                 |    `0x37`| -                  |
-| `i32x4.ne`                 |    `0x38`| -                  |
 | `i32x4.lt_s`               |    `0x39`| -                  |
 | `i32x4.lt_u`               |    `0x3a`| -                  |
 | `i32x4.gt_s`               |    `0x3b`| -                  |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -48,7 +48,6 @@
 | i8x16 Cmp  | opcode | i16x8 Cmp  | opcode | i32x4 Cmp  | opcode |
 | ---------- | ------ | ---------- | ------ | ---------- | ------ |
 | i8x16.eq   | 0x23   | i16x8.eq   | 0x2d   | i32x4.eq   | 0x37   |
-| i8x16.ne   | 0x24   | i16x8.ne   | 0x2e   | i32x4.ne   | 0x38   |
 | i8x16.lt_s | 0x25   | i16x8.lt_s | 0x2f   | i32x4.lt_s | 0x39   |
 | i8x16.lt_u | 0x26   | i16x8.lt_u | 0x30   | i32x4.lt_u | 0x3a   |
 | i8x16.gt_s | 0x27   | i16x8.gt_s | 0x31   | i32x4.gt_s | 0x3b   |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -691,9 +691,6 @@ def S.eq(a, b):
 ```
 
 ### Non-equality
-* `i8x16.ne(a: v128, b: v128) -> v128`
-* `i16x8.ne(a: v128, b: v128) -> v128`
-* `i32x4.ne(a: v128, b: v128) -> v128`
 * `f32x4.ne(a: v128, b: v128) -> v128`
 * `f64x2.ne(a: v128, b: v128) -> v128`
 


### PR DESCRIPTION
Currently WebAssembly SIMD specification includes integer Not Equals instructions. These instructions are problematic, as neither x86 SSE4.1 nor ARM NEON include equivalents of these instructions. In practice, software developers almost always can replace expressions using these Not Equals instructions into equivalent expressions using Equals instructions, and the latter would perform better due to direct mapping on native SIMD instruction sets. In case where Not Equals predicate is desired, it can be emulated as e.g. `i32x4.not(i32x4.eq(a, b))` and would result in the same native code generation as the `i32x4.ne(a, b)`.