### PR TITLE
Prefetch instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -249,3 +249,5 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `v128.store16_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx8  |
 | `v128.store32_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx4  |
 | `v128.store64_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx2  |
+| `prefetch.t`                |     `TBD`| -                        |
+| `prefetch.nt`               |     `TBD`| -                        |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -130,3 +130,8 @@
 | i32x4.trunc_sat_f32x4_u | 0xf9   |
 | f32x4.convert_i32x4_s   | 0xfa   |
 | f32x4.convert_i32x4_u   | 0xfb   |
+
+| Prefetch Op | opcode |
+| ------------| ------ |
+| prefetch.t  | 0xfc   |
+| prefetch.nt | 0xfd   |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1105,3 +1105,13 @@ def S.widen_low_T_u(a):
 def S.widen_high_T_u(a):
     return S.widen_high_T(Zext, a)
 ```
+
+### Prefetch
+
+* `prefetch.t(memarg)`
+* `prefetch.nt(memarg)`
+
+Prefetch memory location into lowest-level cache. Prefetch with temporal hint
+(`prefetch.t`) should be used for data that will be used only once, and
+prefetch with non-temporal (`prefetch.nt`) hint for data that will be reused
+multiple times.


### PR DESCRIPTION
Introduction
=========

Most modern instruction sets include prefetch instructions. These instructions have no explicit effects, but provide a hint to the processor to pre-load soon-to-be-used data from memory into cache. As these instructions have only side-effects, they don't directly affect SIMD register. However, their usage is closely associated with SIMD processing (e.g. on x86 they were added in SSE, and on ARM -- in ARMv7, together with NEON), thus I suggest they should be part of the specification.

Applications
=========

- [BLIS (linear algebra)](https://github.com/flame/blis/blob/1c719c91a3ef0be29a918097652beef35647d4b2/kernels/haswell/3/sup/d6x8/bli_gemmsup_rd_haswell_asm_dMx1.c#L159-L164)
- [XNNPACK (neural network inference)](https://github.com/google/XNNPACK/blob/153011618f766b1ba9e4fae5dc0fcc431587a091/src/f32-spmm/gen/16x1-minmax-neonfma-unroll2.c#L55)
- [Eigen (long vector SIMD library)](https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Core/GenericPacketMath.h#L483)
- [Ruy (matrix multiplication)](https://github.com/google/ruy/blob/59c2de870307b80a59795c3768c954d80159c838/ruy/kernel_arm32.cc#L136)
- [gemmlowp (fixed-point matrix multiplication)](https://github.com/google/gemmlowp/blob/fda83bdc38b118cc6b56753bd540caa49e570745/internal/common.h#L117-L132)
- [ffmpeg (media codecs)](https://github.com/FFmpeg/FFmpeg/blob/a0ac49e38ee1d1011c394d7be67d0f08b2281526/libavcodec/aarch64/videodsp.S#L21-L28)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with SSE instruction set
--------------------------------------------------

- **prefetch.t**
  - `prefetch.t(mem)` is lowered to `PREFETCHT0 [mem]`
- **prefetch.nt**
  - `prefetch.nt(mem)` is lowered to `PREFETCHNTA [mem]`

ARM64 processors
--------------------------------------------------

- **prefetch.t**
  - `prefetch.t(mem)` is lowered to `PRFM PLDL1KEEP, [Xmem]`
- **prefetch.nt**
  - `prefetch.nt(mem)` is lowered to `PRFM PLDL1STRM, [Xmem]`

ARMv7 processors
-------------------------

- **prefetch.t**
  - `prefetch.t(mem)` is lowered to `PLD [Rmem]`
- **prefetch.nt**
  - `prefetch.nt(mem)` is lowered to `PLD [Rmem]`
