### PR TITLE
Add v128 to JS API

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -110,6 +110,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
         text: i32.const
         text: f32.const
         text: f64.const
+        text: v128.const
     text: function index; url: syntax/modules.html#syntax-funcidx
     text: function instance; url: exec/runtime.html#function-instances
     text: store_init; url: appendix/embedding.html#embed-store-init
@@ -150,6 +151,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
         text: i64
         text: f32
         text: f64
+        text: v128
     text: function element; url: exec/runtime.html#syntax-funcelem
     text: import component; url: syntax/modules.html#imports
     text: external value; url: exec/runtime.html#syntax-externval
@@ -362,6 +364,8 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
                 1. If |valtype| is [=i64=] and [=Type=](|v|) is Number,
                     1. Throw a {{LinkError}} exception.
                 1. If |valtype| is not [=i64=] and [=Type=](|v|) is BigInt,
+                    1. Throw a {{LinkError}} exception.
+                1. If |valtype| is [=v128=],
                     1. Throw a {{LinkError}} exception.
                 1. Let |value| be [=ToWebAssemblyValue=](|v|, |valtype|).
                 1. Let |store| be the [=surrounding agent=]'s [=associated store=].
@@ -816,7 +820,8 @@ enum ValueType {
   "i32",
   "i64",
   "f32",
-  "f64"
+  "f64",
+  "v128"
 };
 </pre>
 
@@ -866,6 +871,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. If |s| equals "i64", return [=i64=].
     1. If |s| equals "f32", return [=f32=].
     1. If |s| equals "f64", return [=f64=].
+    1. If |s| equals "v128", return [=v128=].
 </div>
 
 <div algorithm>
@@ -881,6 +887,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     The <dfn constructor for="Global">Global(|descriptor|, |v|)</dfn> constructor, when invoked, performs the following steps:
     1. Let |mutable| be |descriptor|["mutable"].
     1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
+    1. If |valuetype| is [=v128=],
+        1. Throw a {{LinkError}} exception.
     1. If |v| is undefined,
         1. Let |value| be [=DefaultValue=](|valuetype|).
     1. Otherwise,
@@ -896,6 +904,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     The algorithm <dfn>GetGlobalValue</dfn>({{Global}} |global|) performs the following steps:
     1. Let |store| be the current agent's [=associated store=].
     1. Let |globaladdr| be |global|.\[[Global]].
+    1. Let |globaltype| be [=global_type=](|store|, |globaladdr|).
+    1. If |globaltype| is of the form <var ignore>mut</var> [=v128=], throw a {{TypeError}}.
     1. Let |value| be [=global_read=](|store|, |globaladdr|).
     1. Return [=ToJSValue=](|value|).
 </div>
@@ -908,6 +918,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |store| be the current agent's [=associated store=].
     1. Let |globaladdr| be **this**.\[[Global]].
     1. Let |mut| |valuetype| be [=global_type=](|store|, |globaladdr|).
+    1. If |valuetype| is [=v128=], throw a {{TypeError}}.
     1. If |mut| is [=const=], throw a {{TypeError}}.
     1. Let |value| be [=ToWebAssemblyValue=](**the given value**, |valuetype|).
     1. Let |store| be [=global_write=](|store|, |globaladdr|, |value|).
@@ -968,6 +979,9 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |functype| be [=func_type=](|store|, |funcaddr|).
     1. Let [|parameters|] → [<var ignore>results</var>] be |functype|.
+    1. If |parameters| or |results| contain [=v128=], throw a {{TypeError}}.
+
+        Note: the above error is thrown each time the \[[Call]] method is invoked.
     1. Let |args| be « ».
     1. Let |i| be 0.
     1. [=list/iterate|For each=] |t| of |parameters|,
@@ -996,6 +1010,7 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
   To <dfn>run a host function</dfn> from the JavaScript object |func|, type |functype|, and [=list=] of [=WebAssembly values=] |arguments|, perform the following steps:
 
     1. Let [<var ignore>parameters</var>] → [|results|] be |functype|.
+    1. If |parameters| or |results| contain [=v128=], throw a {{TypeError}}.
     1. Let |jsArguments| be « ».
     1. [=list/iterate|For each=] |arg| of |arguments|,
         1. [=list/Append=] ! [=ToJSValue=](|arg|) to |jsArguments|.
@@ -1039,6 +1054,7 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
 <div algorithm>
 The algorithm <dfn>ToJSValue</dfn>(|w|) coerces a [=WebAssembly value=] to a JavaScript value by performing the following steps:
 
+1. Assert: |w| is not of  the form [=v128.const=] <var ignore>v128</var>.
 1. If |w| is of the form [=i64.const=] |i64|,
     1. Let |v| be [=signed_64=](|i64|).
     1. Return a [=BigInt=] representing the mathematical value |v|.
@@ -1053,6 +1069,7 @@ Note: Number values which are equal to NaN may have various observable NaN paylo
 
 The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript value to a [=WebAssembly value=] by performing the following steps:
 
+1. Assert: |type| is not [=v128=].
 1. If |type| is [=i64=],
     1. Let |i64| be ? [=ToBigInt64=](|v|).
     1. Return [=i64.const=] |i64|.


### PR DESCRIPTION
Following the description given in
https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#javascript-api-and-simd-values
and also what I64 did before bigint integration.

js-api tests are not updated yet, that will come in a future patch.