### PR TITLE
Saturating Rounding Q-format Multiplication

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -161,7 +161,7 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i16x8.min_u`               |    `0x97`| -                  |
 | `i16x8.max_s`               |    `0x98`| -                  |
 | `i16x8.max_u`               |    `0x99`| -                  |
-| `i16x8.avgr_u`              |    `0x9b`|                    |
+| `i16x8.avgr_u`              |    `0x9b`| -                  |
 | `i32x4.abs`                 |    `0xa0`| -                  |
 | `i32x4.neg`                 |    `0xa1`| -                  |
 | `i32x4.any_true`            |    `0xa2`| -                  |
@@ -237,3 +237,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i64x2.extmul_high_i32x4_s` |   `0x119`| -                  |
 | `i64x2.extmul_low_i32x4_u`  |   `0x11a`| -                  |
 | `i64x2.extmul_high_i32x4_u` |   `0x11b`| -                  |
+| `i16x8.q15mulr_sat_s`       |     `TBD`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -130,6 +130,7 @@
 | `i16x8.max_s`               |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.max_u`               |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.avgr_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i16x8.q15mulr_sat_s`       |                           |                    |                    |                    |                    |
 | `i32x4.abs`                 |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.any_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -509,6 +509,19 @@ def S.sub_sat_u(a, b):
     return S.lanewise_binary(subsat, S.AsUnsigned(a), S.AsUnsigned(b))
 ```
 
+### Saturating integer Q-format rounding multiplication
+
+* `i16x8.q15mulr_sat_s(a: v128, b: v128) -> v128`
+
+Lane-wise saturating rounding multiplication in Q15 format:
+
+```python
+def S.q15mulr_sat_s(a, b):
+    def subq15mulr(x, y):
+        return S.SignedSaturate((x * y + 0x4000) >> 15)
+    return S.lanewise_binary(subsat, S.AsSigned(a), S.AsSigned(b))
+```
+
 ### Lane-wise integer minimum
 * `i8x16.min_s(a: v128, b: v128) -> v128`
 * `i8x16.min_u(a: v128, b: v128) -> v128`


### PR DESCRIPTION
Introduction
=========

Fixed-point algorithms often represent fractional numbers in [Q format](https://en.wikipedia.org/wiki/Q_(number_format)), where a fixed number of bits is allocated to fractional part. Addition and subtraction in Q format are no different than addition and subtraction on integers, but multiplication is substantially different. First, to produce multiplication result in the same Q format as the factors, we need to compute the full (i.e. with twice the number of bits of the factors) product of the factors, and then do arithmetic shift right by Q bits. Secondly, as the right shift loses some of the bits of the product, it is typically done with rounding to nearest Q-format number to minimize the rounding error. Thus, for Q15 format (i.e. with 15 fractional bits) the multiplication result is computed as `(a * b + 0x4000) >> 15` where `a` and `b` are integer representation of the input factors.

Despite sophisticated low-level definition, Q-format multiplication is commonly used in fixed-point algorithms, and widely supported in hardware. x86 since SSSE3 supports multiplication of 16-bit numbers in Q15 format, and ARM NEON supports multiplication of 16-bit numbers in Q15 format and 32-bit numbers in Q31 format. This proposal suggests to add 16-bit Q15-format multiplication to WebAssembly SIMD instruction set. The native x86 and ARM variants of this instruction differ in how they handle overflow: x86 version wraps around while ARM version saturates. The overflow happens only when both inputs are `INT16_MIN`, and can be corrected with a couple of instructions. For the purpose of bitwise compatibility this proposal standardize on the saturating variant as the more mathematically meaningful.

Q-format multiplication instruction is particularly important for fixed-point neural network inference, and was previously requested by @bjacob in #221.

Applications
=========

- [libvpx (video codec)](https://github.com/webmproject/libvpx/blob/a5d499e16570d00d5e1348b1c7977ced7af3670f/vpx_dsp/x86/inv_txfm_ssse3.h#L47-L52)
- [AV1 Codec Library (video codec)](https://github.com/mozilla/aom/blob/c8b38b0bfd36306f1886375d98512d792ffe9517/aom_dsp/x86/aom_subpixel_8t_intrin_ssse3.c#L797-L798)
- [OpenVINO (machine learning toolkit)](https://github.com/openvinotoolkit/openvino/blob/efad27d68ca88a107f9980b7dd8f07556a9eaf03/inference-engine/src/preprocessing/cpu_x86_sse42/ie_preprocess_gapi_kernels_sse42.cpp#L106-L109)
- [gemmlowp (fixed-point matrix multiplication)](https://github.com/google/gemmlowp/blob/023c190f9341198e2cbdbac39b184a78f6f90806/fixedpoint/fixedpoint_sse.h#L359-L368)
- [skia (2D graphics library)](https://github.com/google/skia/blob/52a4379f03f7cd4e1c67eb69a756abc5838a658f/src/core/SkFixed15.h#L67-L69)
- [WebRTC library](https://webrtc.googlesource.com/src/+/92ea95e34af5966555903026f45164afbd7e2088/modules/audio_coding/codecs/isac/fix/source/lattice_neon.c#55)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **y = i16x8.q15mulr_sat_s(a, b)** is lowered to
  - `VPMULHRSW xmm_y, xmm_a, xmm_b`
  - `VPCMPEQW xmm_tmp, xmm_y, wasm_i16x8_splat(0x8000)`
  - `VPXOR xmm_y, xmm_y, xmm_tmp`

x86/x86-64 processors with SSSE3 instruction set
--------------------------------------------------

- **y = i16x8.q15mulr_sat_s(a, b)** is lowered to
  - `MOVDQA xmm_y, xmm_a`
  - `MOVDQA xmm_tmp, wasm_i16x8_splat(0x8000)`
  - `PMULHRSW xmm_y, xmm_b`
  - `PCMPEQW xmm_tmp, xmm_y`
  - `PXOR xmm_y, xmm_tmp`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **y = i16x8.q15mulr_sat_s(a, b)** (`y` is **NOT** `a` and `y` is **NOT** `b`) is lowered to
  - `MOVDQA xmm_y, xmm_a`
  - `MOVDQA xmm_tmp, xmm_a`
  - `PMULLW xmm_y, xmm_b`
  - `PMULHW xmm_tmp, xmm_b`
  - `PSRLW xmm_y, 14`
  - `PADDW xmm_tmp, xmm_tmp`
  - `PAVGW xmm_y, wasm_i16x8_splat(0)`
  - `PADDW xmm_y, xmm_tmp`
  - `MOVDQA xmm_tmp, wasm_i16x8_splat(0x8000)`
  - `PCMPEQW xmm_tmp, xmm_y`
  - `PXOR xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------

- **y = i16x8.q15mulr_sat_s(a, b)** is lowered to
  - `SQRDMULH Vy.8H, Va.8H, Vb.8H `

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **y = i16x8.q15mulr_sat_s(a, b)** is lowered to
  - `VQRDMULH.S16 Qy, Qa, Qb`
