### PR TITLE
move{32,64}_zero_{r,v} instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -222,3 +222,7 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
+| `v128.move32_zero_r`       |    `0xfe`| -                  |
+| `v128.move32_zero_v`       |    `0xff`| -                  |
+| `v128.move64_zero_r`       |   `0x100`| -                  |
+| `v128.move64_zero_v`       |   `0x101`| -                  | 

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -190,6 +190,10 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `v128.move32_zero_r`       |                           |                                         |                    |                    |
+| `v128.move32_zero_v`       |                           |                                         |                    |                    |
+| `v128.move64_zero_r`       |                           |                                         |                    |                    |
+| `v128.move64_zero_v`       |                           |                                         |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1023,3 +1023,33 @@ def S.widen_low_T_u(a):
 def S.widen_high_T_u(a):
     return S.widen_high_T(Zext, a)
 ```
+
+
+### Move and Zero-Pad
+
+* `v128.move32_zero_r(x: i32) -> v128`
+* `v128.move32_zero_v(a: v128) -> v128`
+* `v128.move64_zero_r(x: i64) -> v128`
+* `v128.move64_zero_v(a: v128) -> v128`
+
+Move a single 32-bit or 64-bit element into the lowest bits of `v128` vector,
+and initialize all other bits of the `v128` vector to zero.
+```python
+def S.moveT_zero_r(x):
+    result = S.New()
+    for i in range(S.Lanes):
+        if i == 0:
+            result[i] = x
+        else:
+            result[i] = 0
+    return result
+
+def S.moveT_zero_v(a):
+    result = S.New()
+    for i in range(S.Lanes):
+        if i == 0:
+            result[i] = a[i]
+        else:
+            result[i] = 0
+    return result
+```


### PR DESCRIPTION
# Introduction
@Maratyszcza has done a wonderful job describing the use cases and functionality of load64_zero and load32_zero in #237.  This proposal seeks to extend the functionality of load64_zero and load32_zero to be functionally complete with the underlying architecture by adding support for its sister variants with identical implementations.  This would add support from other 32-bit and 64-bit registers and from the low 32 and 64 bits of other vectors.  The proposed instructions are  move32_zero_r, move64_zero_r, move32_zero_v, and move64_zero_v respectively. Since these are sister instructions, the applications, use cases, and instructions are identical to the original proposal. 


# Mapping to Common Instruction Sets
This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

## x86/x86-64 processors with AVX instruction set
### v128.move32_zero_r
#### v = v128.move32_zero_r(r32) is lowered to VMOVD xmm_v, r32
### v128.move64_zero_r
#### v = v128.move64_zero_r(r64) is lowered to VMOVQ xmm_v, r64
### v128.move32_zero_v
#### v = v128.move32_zero_v(v128) is lowered to 
```
        vxorps  xmm1, xmm1, xmm1
        vblendps        xmm0, xmm1, xmm0, 1             # xmm0 = xmm0[0],xmm1[1,2,3]
```
### v128.move64_zero_v
#### v = v128.move64_zero_v(v128) is lowered to VMOVQ xmm_v, xmm

## x86/x86-64 processors with SSE2 instruction set
### v128.move32_zero_r
#### v = v128.move32_zero_r(r32) is lowered to MOVD xmm_v, r32
### v128.move64_zero_r
#### v = v128.move64_zero_r(r64) is lowered to MOVQ xmm_v, r64
### v128.move32_zero_v
#### v = v128.move32_zero_v(v128) is lowered to 
```
        xorps   xmm1, xmm1
        movss   xmm1, xmm0                      # xmm1 = xmm0[0],xmm1[1,2,3]
        movaps  xmm0, xmm1
```
### v128.move64_zero_v
#### v = v128.move64_zero_v(v128) is lowered to MOVQ xmm_v, xmm

## ARM64 Processors
### v128.move32_zero_r 
#### v = v128.move32_zero_r(r32) is lowered to fmov s0, w0
### v128.move64_zero_r
#### v = v128.move64_zero_r(r64) is lowered to fmov d0, x0
### v128.move32_zero_v
#### v = v128.move32_zero_v(v128) is lowered to fmov s0, s1
### v128.move64_zero_v
#### v = v128.move64_zero_v(v128) is lowered to fmov d0, d1
## ARMv7 with Neon
### v128.move32_zero_r
#### v = v128.move32_zero_r(r32) is lowered to
```
        movi    v0.2d, #0000000000000000
        mov     v0.s[0], w0
```
### v128.move64_zero_r
#### v = v128.move32_zero_r(r64) is lowered to
```
        movi    v0.2d, #0000000000000000
        mov     v0.d[0], x0
```
### v128.move32_zero_v
#### v = v128.move32_zero_v(v128) is lowered to
```
        movi    v1.2d, #0000000000000000
        mov     v1.s[0], v0.s[0]
        mov     v0.16b, v1.16b
```
### v128.move64_zero_v(v128) is lowered to
```
        movi    v0.2d, #0000000000000000
        mov     v0.d[0], x0
```
