### PR TITLE
f32x4.add_pairwise and f64x2.add_pairwise

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -222,3 +222,5 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
+| `f32x4.add_pairwise`       |    `0xfe`| -                  |
+| `f64x2.add_pairwise`       |    `0xff`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -190,6 +190,8 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `f32x4.add_pairwise`       |                           |                    |                    |                    |                    |
+| `f64x2.add_pairwise`       |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -938,6 +938,14 @@ Lane-wise rounding to the nearest integral value with the magnitude not larger t
 
 Lane-wise rounding to the nearest integral value; if two values are equally near, rounds to the even one.
 
+## Pairwise Arithmetics
+
+### Addition
+* `f32x4.add_pairwise(a: v128, b: v128) -> v128`
+* `f64x2.add_pairwise(a: v128, b: v128) -> v128`
+
+IEEE `addition` of pairs of elements in concantation of `a` and `b` vectors.
+
 ## Conversions
 ### Integer to floating point
 * `f32x4.convert_i32x4_s(a: v128) -> v128`


### PR DESCRIPTION
Introduction
=========

Pairwise addition (AKA horizontal addition) is a SIMD operation that computed sums within adjacent pairs of lanes in the concatenation of two SIMD registers. Floating-point pairwise addition is supported on both x86 (since SSE3) and ARM (since NEON) and comprise a commonly used primitive for full and partial sums on SIMD vectors.

Besides pairwise addition, x86 supports pairwise subtraction. ARM doesn't support pairwise subtraction, but offers pairwise maximum and minimum operation. Pairwise subtraction, minimum, and maximum were left out of this PR as each of them would benefit only a single architecture.

Applications
=========

- [OpenCV library for image processing](https://github.com/opencv/opencv/blob/152e6476d9a270e6ce35d3f1b200a303654e576e/modules/core/include/opencv2/core/hal/intrin_sse.hpp#L1729-L1731)
- [DirectXMath support library for 3D games](https://github.com/microsoft/DirectXMath/blob/83634c742a85d1027765af53fbe79506fd72e0c3/Extensions/DirectXMathSSE3.h#L74-L75)
- [Eigen library for general vector computations](https://github.com/eigenteam/eigen-git-mirror/blob/7878df97cfe15ad276952cbd1de634a0e2402fd8/Eigen/src/Core/arch/SSE/PacketMath.h#L678-L686)
- [PhysX library for game physics](https://github.com/NVIDIAGameWorks/PhysX/blob/ae80dede0546d652040ae6260a810e53e20a06fa/physx/source/foundation/include/unix/sse2/PsUnixSse2InlineAoS.h#L1584-L1586)
- [PyTorch framework for neural network inference](https://github.com/pytorch/pytorch/blob/e154b36685330a819d96c2e4482ccf1cd06abba4/aten/src/ATen/cpu/vec256/vec256_complex_float.h#L152)
- [Microsoft ONNX Runtime framework for neural network inference](https://github.com/microsoft/onnxruntime/blob/79e27d937aba6fe4224eadcb765e92c8e6d15300/onnxruntime/core/mlas/lib/mlasi.h#L1503-L1505)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **f32x4.add_pairwise**
  - `y = f32x4.add_pairwise(a, b)` is lowered to `VHADDPS xmm_y, xmm_a, xmm_b`
- **f64x2.add_pairwise**
  - `y = f64x2.add_pairwise(a, b)` is lowered to `VHADDPD xmm_y, xmm_a, xmm_b`

x86/x86-64 processors with SSE3 instruction set
--------------------------------------------------

- **f32x4.add_pairwise**
  - `y = f32x4.add_pairwise(a, b)` (`y` is **NOT** `b`) is lowered to 'MOVAPS xmm_y, xmm_a` + `HADDPS xmm_y, xmm_b`
- **f64x2.add_pairwise**
  - `y = f64x2.add_pairwise(a, b)` (`y` is **NOT** `b`) is lowered to `MOVAPS xmm_y, xmm_a` + `HADDPD xmm_y, xmm_b`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **f32x4.add_pairwise**
  - `y = f32x4.add_pairwise(a, b)` (`y` is **NOT** `b`) is lowered to `MOVAPS xmm_y, xmm_a` + 'MOVAPS xmm_tmp, xmm_a` + `SHUFPS xmm_y, xmm_b, 0x88` + `SHUFPS xmm_tmp, xmm_b, 0x88` + `ADDPS xmm_y, xmm_tmp`
- **f64x2.add_pairwise**
  - `y = f64x2.add_pairwise(a, b)` (`y` is **NOT** `b`) is lowered to `MOVAPS xmm_tmp, xmm_b` + `MOVHLPS xmm_tmp, xmm_a` + `MOVSD xmm_y, xmm_a` + `MOVLHPS xmm_y, xmm_b` + ADDPD xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------

- **f32x4.add_pairwise**
  - `y = f32x4.add_pairwise(a, b)` is lowered to `FADDP Vy.4S, Va.4S, Vb.4S`
- **f64x2.add_pairwise**
  - `y = f64x2.add_pairwise(a, b)` is lowered to `FADDP Vy.2D, Va.2D, Vb.2D`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **f32x4.add_pairwise**
  - `y = f32x4.add_pairwise(a, b)` is lowered to `VPADD.F32 Dy_lo, Da_lo, Db_lo` + `VPADD.F32 Dy_hi, Da_hi, Db_hi`
- **f64x2.add_pairwise**
  - `y = f64x2.add_pairwise(a, b)` is lowered to `VADD.F64 Dy_lo, Da_lo, Db_lo` + `VADD.F64 Dy_hi, Da_hi, Db_hi`
