### PR TITLE
Update README to require Ocaml 4.08

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -15,7 +15,7 @@ The text format defines modules in S-expression syntax. Moreover, it is generali
 
 ## Building
 
-You'll need OCaml 4.07 or higher. Instructions for installing a recent version of OCaml on multiple platforms are available [here](https://ocaml.org/docs/install.html). On most platforms, the recommended way is through [OPAM](https://ocaml.org/docs/install.html#OPAM).
+You'll need OCaml 4.08 or higher. Instructions for installing a recent version of OCaml on multiple platforms are available [here](https://ocaml.org/docs/install.html). On most platforms, the recommended way is through [OPAM](https://ocaml.org/docs/install.html#OPAM).
 
 Once you have OCaml, simply do
 


### PR DESCRIPTION
Replaces #158. @dschuff added 4.08.01 tarball https://wasm.storage.googleapis.com/ as well.

Btw we want 4.08 since we use various functions in https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bytes.html