### PR TITLE
Population count instruction

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -258,3 +258,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f64x2_u_zero` |     `TBD`| -                        |
 | `f32x4.demote_f64x2_zero`      |     `TBD`| -                        |
 | `f64x2.promote_low_f32x4`      |     `TBD`| -                        |
+| `i8x16.popcnt`                 |     `TBD`| -                        |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -226,6 +226,7 @@
 | `i32x4.trunc_sat_f64x2_u_zero` |                           |                    |                    |                    |                    |
 | `f32x4.demote_f64x2_zero`      |                           |                    |                    |                    |                    |
 | `f64x2.promote_low_f32x4`      |                           |                    |                    |                    |                    |
+| `i8x16.popcnt`              |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -662,6 +662,15 @@ Note that the normal WebAssembly `select` instruction also works with vector
 types. It selects between two whole vectors controlled by a single scalar value,
 rather than selecting bits controlled by a control mask vector.
 
+### Lane-wise Population Count
+* `i8x16.popcnt(v: v128) -> v128`
+
+Count the number of bits set to one within each lane.
+
+```python
+def S.popcnt(v):
+    return S.lanewise_unary(popcnt, v)
+```
 
 ## Boolean horizontal reductions
 


### PR DESCRIPTION
Introduction
=========

The PR introduce a SIMD variant of Population Count operation. This operation counts the number of bits set to 1, is commonly used in algorithms involving Hamming distance between two binary vectors. Population Count is represented in the scalar WebAssembly instruction set, and many native SIMD instruction sets. E.g. ARM NEON and AVX512BITALG extensions natively support the 8-bit lane variant introduced in this proposal. Implementation in SSSE3 is less trivial, but still more efficient than emulation with `i8x16.swizzle` instruction due to elimination of `PADDUSB` instruction and direct lowering of table lookups into `PSHUFB`. Moreover, the SIMD Population Count can be efficiently implemented on SSE2-level processors where `i8x16.swizzle`-based emulation would have been scalarized.

Applications
=========

- [Hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) (e.g. implemented in [Fast Library for Approximate Nearest Neighbors (FLANN)](https://github.com/mariusmuja/flann/blob/1d04523268c388dabf1c0865d69e1b638c8c7d9d/src/cpp/flann/algorithms/dist.h#L490) and [OpenCV computer vision library](https://github.com/opencv/opencv/blob/fc1a15626226609babd128e043cf7c4e32f567ca/modules/core/include/opencv2/core/hal/intrin_neon.hpp#L1357-L1372))
- [N-point correlations](https://dl.acm.org/doi/10.5555/2388996.2389097)
- [Binary neural networks](https://arxiv.org/abs/1603.05279) (e.g. implemented in [larq/compute-engine](https://github.com/larq/compute-engine) and [Blueoil](https://github.com/blue-oil/blueoil/blob/002f5408d11fd2a93457c5e7bc8dc876ace13ce0/blueoil/converter/templates/src/func/impl/arm_neon/quantized_conv2d_tiling.cpp#L232-L235), cc @lgeiger)
- [Ultra low precision neural networks](https://arxiv.org/abs/1712.02427) (implemented in [Caffe2/PyTorch](https://github.com/pytorch/pytorch/blob/22a34bcf4e5eaa348f0117c414c3dd760ec64b13/caffe2/mobile/contrib/ulp2/ulp_neon.cc#L319), cc @ajtulloch)
- [2D similarity in chemical informatics](https://pubs.acs.org/doi/10.1021/ci200235e)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX512BITALG and AVX512VL instruction sets
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to `VPOPCNTB xmm_y, xmm_x`

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to:
    - `VMOVDQA xmm_tmp0, [wasm_i8x16_splat(0x0F)]`
    - `VPANDN xmm_tmp1, xmm_tmp0, xmm_x`
    - `VPAND xmm_y, xmm_tmp0, xmm_x`
    - `VMOVDQA xmm_tmp0, [wasm_i8x16_const(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)]`
    - `VPSRLW xmm_tmp1, xmm_tmp1, 4`
    - `VPSHUFB xmm_y, xmm_tmp0, xmm_y`
    - `VPSHUFB xmm_tmp1, xmm_tmp0, xmm_tmp1`
    - `VPADDB xmm_y, xmm_y, xmm_tmp1`

x86/x86-64 processors with SSSE3 instruction set
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to:
    - `MOVDQA xmm_tmp0, [wasm_i8x16_splat(0x0F)]`
    - `MOVDQA xmm_tmp1, xmm_x`
    - `PAND xmm_tmp1, xmm_tmp0`
    - `PANDN xmm_tmp0, xmm_x`
    - `MOVDQA xmm_y, [wasm_i8x16_const(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)]`
    - `PSRLW xmm_tmp0, 4`
    - `PSHUFB xmm_y, xmm_tmp1`
    - `MOVDQA xmm_tmp1, [wasm_i8x16_const(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)]`
    - `PSHUFB xmm_tmp1, xmm_tmp0`
    - `PADDB xmm_y, xmm_tmp1`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to (based on @WojciechMula's algorithm [here](https://github.com/WojciechMula/sse-popcount/blob/master/popcnt-sse-bit-parallel-better.cpp#L33-L35)):
    - `PXOR xmm_tmp, xmm_tmp`
    - `PAVGB xmm_tmp, xmm_x`
    - `MOVDQA xmm_y, xmm_x`
    - `PAND xmm_tmp, [wasm_i8x16_splat(0x55)]`
    - `PSUBB xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_y`
    - `PAND xmm_y, [wasm_i8x16_splat(0x33)]`
    - `PSRLW xmm_tmp, 2`
    - `PAND xmm_tmp, [wasm_i8x16_splat(0x33)]`
    - `PADDB xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_y`
    - `PSRLW xmm_tmp, 4`
    - `PADDB xmm_y, xmm_tmp`
    - `PAND xmm_y, [wasm_i8x16_splat(0x0F)]`

ARM64 processors
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to `CNT Vy.16B, Vx.16B`

ARMv7 processors with NEON instruction set
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to `VCNT.8 Qy, Qx`

POWER processors with POWER 2.07+ instruction set and VMX
--------------------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to `VPOPCNTB VRy, VRx`

MIPS processors with MSA instruction set
------------------------------------

- **i8x16.popcnt**
  - `y = i8x16.popcnt(x)` is lowered to `PCNT.B Wy, Wx`
