### PR TITLE
i64x2.eq instruction

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -249,3 +249,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `v128.store16_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx8  |
 | `v128.store32_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx4  |
 | `v128.store64_lane`         |     `TBD`| m:memarg, i:ImmLaneIdx2  |
+| `i64x2.eq`                  |     `TBD`| -                        |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -148,6 +148,7 @@
 | `i32x4.max_s`               |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_u`               |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.dot_i16x8_s`         |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i64x2.eq`                  |                           |                    |                    |                    |                    |
 | `i64x2.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i64x2.bitmask`             |                           | :heavy_check_mark: |                    |                    |                    |
 | `i64x2.shl`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -717,6 +717,7 @@ in each lane are `0` for `false` and all ones for `true`.
 * `i8x16.eq(a: v128, b: v128) -> v128`
 * `i16x8.eq(a: v128, b: v128) -> v128`
 * `i32x4.eq(a: v128, b: v128) -> v128`
+* `i64x2.eq(a: v128, b: v128) -> v128`
 * `f32x4.eq(a: v128, b: v128) -> v128`
 * `f64x2.eq(a: v128, b: v128) -> v128`
 


### PR DESCRIPTION
Introduction
=========

This is proposal to add 64-bit variant of existing `eq` instruction. ARM64 and x86 (since SSE4.1) natively support this instruction, and on ARMv7 NEON and SSE2 is can be efficiently emulated with 3-4 instructions.

Applications
=========

- [Boost.Atomic library](https://github.com/boostorg/atomic/blob/4b2edae1a7dcbd2be1c088ddc05acb0634e69a15/src/find_address_sse41.cpp#L55-L62)
- [SUPERCOP cryptography library](https://github.com/jedisct1/supercop/blob/a4203f1f35c3dac9b96a9ae297f13e22151428e0/crypto_dh/gls254/opt/smu.h#L236-L251)
- [Flang compiler runtime library](https://github.com/flang-compiler/flang/blob/a21454d4a0e27e31743864e389a66b1fd95fbac0/runtime/libpgmath/lib/common/pow/fma3/sdpow.cpp#L115)
- [BearSSL cryptography library](https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/symcipher/aes_x86ni_ctrcbc.c;h=f57fead6858a1b7de132a6276d627c9c2d0e6713;hb=HEAD#l84)
- [Plato framework for distributed graph computations and machine learning](https://github.com/Tencent/plato/blob/28fd58ffcbfa8a9e1365a90371eccf010429b3f0/plato/util/intersection_impl.hpp#L215-L216)
- [BESS (Berkeley Extensible Software Switch) framework](https://github.com/NetSys/bess/blob/ae52fc5804290fc3116daf2aef52226fafcedf5d/core/packet_avx.h#L87-L89)
- [LightMatrix library for matrix computation](https://github.com/lindahua/light-matrix/blob/8ce65d14b6027ee9e081dd12460bc714e9131d11/light_mat/simd/internal/sse_fpclass_impl.h#L75)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i64x2.eq**
  - `y = i64x2.eq(a, b)` is lowered to `VPCMPEQQ xmm_y, xmm_a, xmm_b`


x86/x86-64 processors with SSE4.1 instruction set
--------------------------------------------------
- **i64x2.eq**
  - `y = i64x2.eq(a, b)` is lowered to `MOVDQA xmm_y, xmm_a` + `PCMPEQQ xmm_y, xmm_b`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------
- **i64x2.eq**
  - `y = i64x2.eq(a, b)` is lowered to:
    - `MOVDQA xmm_y, xmm_a`
    - `PCMPEQD xmm_y, xmm_b`
    - `PSHUFD xmm_tmp, xmm_y, 0xB1`
    - `PAND xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------
- **i64x2.eq**
  - `y = i64x2.eq(a, b)` is lowered to `CMEQ Vy.2D, Va.2D, Vb.2D`

ARMv7 processors with NEON instruction set
--------------------------------------------------
- **i64x2.eq**
  - `y = i64x2.eq(a, b)` is lowered to:
    - `VCEQ.I32 Qy, Qa, Qb`
    - `VREV64.32 Qtmp, Qy`
    - `VAND Qy, Qtmp`
