### PR TITLE
Extended multiply horizontal add instruction

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -222,4 +222,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
-| `u8x16.ext_mul_padd_u8`    |          | -                  |
+| `i16x8.extmul_padd_i8x16_u`|          | -                  |

--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -222,3 +222,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i32x4.trunc_sat_f32x4_u`  |    `0xf9`| -                  |
 | `f32x4.convert_i32x4_s`    |    `0xfa`| -                  |
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
+| `u8x16.ext_mul_padd_u8`    |          | -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -190,7 +190,7 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `u8x16.ext_mul_padd_u8`    |                           |                    |                    |                    |                    |
+| `i16x8.extmul_padd_i8x16_u`|                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -190,6 +190,7 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `u8x16.ext_mul_padd_u8`    |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1026,13 +1026,13 @@ def S.widen_high_T_u(a):
 
 
 ### Horizontal Multiply Extend and Add
-* `u8x16.ext_mul_padd_u8(a: v128, b: v128) -> v128`
+* `i16x8.extmul_padd_i8x16_u(a: v128, b: v128) -> v128`
 
 Multiplies two u8x16 vectors, temporarily expands the values to two i16x8s, before performing 
 pairwise addition leading to one i16x8/u16x8.
 
 ```python
-def S.ext_mul_padd_u8(a, b):
+def S.extmul_padd_i8x16_u(a, b):
     result = S.New()
     for i in S.range(S.Lanes/2):
         result[i] = (a[i]*b[i])+(a[i+1]*b[i+1])

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1023,3 +1023,18 @@ def S.widen_low_T_u(a):
 def S.widen_high_T_u(a):
     return S.widen_high_T(Zext, a)
 ```
+
+
+### Horizontal Multiply Extend and Add
+* `u8x16.ext_mul_padd_u8(a: v128, b: v128) -> v128`
+
+Multiplies two u8x16 vectors, temporarily expands the values to two i16x8s, before performing 
+pairwise addition leading to one i16x8/u16x8.
+
+```python
+def S.ext_mul_padd_u8(a, b):
+    result = S.New()
+    for i in S.range(S.Lanes/2):
+        result[i] = (a[i]*b[i])+(a[i+1]*b[i+1])
+    return result
+```


### PR DESCRIPTION
# Introduction
This proposal introduces the extended horizontal multiply and add instruction that is used extensively in colorspace conversion and in the implementation of encoders and decoder for video processing.  It maps to a single instruction on x86_64 and 3 instructions on ARM64.

# Applications
- x264 [1](https://github.com/mirror/x264/blob/33f9e1474613f59392be5ab6a7e7abf60fa63622/common/x86/pixel-a.asm#L396), [2](https://github.com/mirror/x264/blob/33f9e1474613f59392be5ab6a7e7abf60fa63622/common/x86/mc-a.asm#L298) [3](https://github.com/mirror/x264/blob/33f9e1474613f59392be5ab6a7e7abf60fa63622/common/x86/predict-c.c#L103)
- [x265](https://github.com/videolan/x265/blob/master/source/common/x86/pixel-a.asm#L106)
- [Base64 Encoding / Decoding](https://arxiv.org/pdf/1704.00605.pdf)
- [PJSIP](https://trac.pjsip.org/repos/changeset/5633/pjproject/trunk/third_party/yuv/source/row_win.cc?old=5699&old_path=pjproject%2Ftrunk%2Fthird_party%2Fyuv%2Fsource%2Frow_win.cc)

# Mapping to Common Instruction Sets
This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

## x86/x86-64 processors with AVX instruction set
- i16x8.extmul_padd_i8x16_u
  - y = i16x8.extmul_padd_i8x16_u(x) is lowered to VPMADDUBSW xmm_y, xmm_x
## x86/x86-64 processors with SSSE3 instruction set
- i16x8.extmul_padd_i8x16_u
  - y = i16x8.extmul_padd_i8x16_u(x) is lowered to PMADDUBSW xmm_y, xmm_x
## x86/x86-64 processors with SSE2 instruction set
- i16x8.extmul_padd_i8x16_u
  - y = i16x8.extmul_padd_i8x16_u(x) is lowered to:
```assembly
        movdqa  xmm3, xmmword ptr [...] # xmm3 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
        movdqa  xmm2, xmm0
        pand    xmm2, xmm3
        pand    xmm3, xmm1
        pmullw  xmm2, xmm3
        psrlw   xmm0, 8
        psrlw   xmm1, 8
        pmullw  xmm1, xmm0
        paddw   xmm2, xmm1
        movdqa  xmm0, xmm2
```
## ARM64 processors
- i16x8.extmul_padd_i8x16_u
  - y = i16x8.extmul_padd_i8x16_u(x) is lowered to:
```assembly
        umull   v2.8h, v0.8b, v1.8b
        umull2  v0.8h, v0.16b, v1.16b
        addp    v0.8h, v2.8h, v0.8h
```
## ARMv7 processors with NEON instruction set
- i16x8.extmul_padd_i8x16_u
  - y = i16x8.extmul_padd_i8x16_u(x) is lowered to:
```assembly
        vmull.u8        q10, d18, d17
        vmull.u8        q8, d19, d16
        vpadd.i16       d19, d20, d21
        vpadd.i16       d18, d16, d17
```




