### PR TITLE
Update SpiderMonkey implementation status

### DIFF
--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -149,7 +149,7 @@
 | `i32x4.min_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.max_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `i32x4.dot_i16x8_s`        |                           | :heavy_check_mark: |                    |                    |                    |
+| `i32x4.dot_i16x8_s`        |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.neg`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shl`                |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i64x2.shr_s`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -191,8 +191,8 @@
 | `i32x4.trunc_sat_f32x4_u`  |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_s`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
-| `v128.load32_zero`         |                           | :heavy_check_mark: |                    |                    |                    |
-| `v128.load64_zero`         |                           | :heavy_check_mark: |                    |                    |                    |
+| `v128.load32_zero`         |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `v128.load64_zero`         |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 
 [1] Tip of tree LLVM as of May 20, 2020
 


### PR DESCRIPTION
Dot and LoadZero landed a while back, should be in FF83.