### PR TITLE
#372 Integer Sign/Zero Extension for {8,16}->{32,64}

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -225,3 +225,9 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `f32x4.convert_i32x4_u`    |    `0xfb`| -                  |
 | `v128.load32_zero`         |    `0xfc`| -                  |
 | `v128.load64_zero`         |    `0xfd`| -                  |
+| `i32x4.widen_i8x16_u`      |          | -                  |
+| `i32x4.widen_i8x16_s`      |          | -                  |
+| `i64x2.widen_i8x16_u`      |          | -                  |
+| `i64x2.widen_i8x16_s`      |          | -                  |
+| `i64x2.widen_i16x8_u`      |          | -                  |
+| `i64x2.widen_i16x8_s`      |          | -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -193,6 +193,12 @@
 | `f32x4.convert_i32x4_u`    |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `v128.load32_zero`         |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `v128.load64_zero`         |                           | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
+| `i32x4.widen_i8x16_u`      |                           | -                  |                    |                    |                    |
+| `i32x4.widen_i8x16_s`      |                           | -                  |                    |                    |                    |
+| `i64x2.widen_i8x16_u`      |                           | -                  |                    |                    |                    |
+| `i64x2.widen_i8x16_s`      |                           | -                  |                    |                    |                    |
+| `i64x2.widen_i16x8_u`      |                           | -                  |                    |                    |                    |
+| `i64x2.widen_i16x8_s`      |                           | -                  |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -1046,3 +1046,25 @@ def S.widen_low_T_u(a):
 def S.widen_high_T_u(a):
     return S.widen_high_T(Zext, a)
 ```
+### Integer to integer Widening (Constant Immediate)
+* `i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128`
+* `i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128`
+* `i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128`
+* `i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128`
+* `i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128`
+* `i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128`
+
+Using the constant immediate, widens selected integers with zero or sign extension.
+```python
+def S.widen_T_u(a,c):
+    result = S.New()
+    for i in range(S.Lanes):
+            result[i] = Zext(a[S.Lanes + i + c])
+    return result
+
+def S.widen_T_s(a,c):
+    result = S.New()
+    for i in range(S.Lanes):
+            result[i] = Sext(a[S.Lanes + i + c])
+    return result
+```


### PR DESCRIPTION
# Introduction
This proposal mirrors #290 to add new variants of existing widen instructions and extends the 32 and 64 widen instructions to include support from 16 and 8-bit integers. The practical use case for this is signal processing -- specifically audio and image processing, but the use cases for this are pretty large in general. For a non-image processing use case, these could be very helpful any time someone wants to convert an 8-bit value to a floating-point number. Currently, this requires multiple conversions steps between integers before converting to float, but modern architectures provide operations to convert from just about any integer size to another. Due to the non-binary relationship between 8 bits and 64 bits, this instruction will introduce new terminology that will replace the high/low terminology with a constant parameter immediate. This PR supersedes #372 to provide the implementation guidelines for this proposal.
# Use Cases
- Audio Digital Signal Processing (8/16-bit data) -> 32/64bits
- Image/Video Digital Signal Processing (8-bit data) -> 32/64bits
- Prefix Sums / Scan Algorithms
# Notable Applications and Libraries
- Alliance for Open Media  (https://github.com/mozilla/aom)
- Seqan3 (https://github.com/seqan/seqan3)
- SIMDPP (https://github.com/p12tic/libsimdpp)
- Structural Similarity (SSIM) (port in progress)
# Proposed Instructions
- i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
- i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128

<details>
<summary>Withdrawn instructions</summary>

- i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
- i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
- i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
- i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128

</details>

# Performance and Portability Considerations
The principal implementation is that of a shuffle/swizzle and shift for signed data and merely a shuffle/swizzle for unsigned data.
Analysis describing the efficacy of this proposal is described [here](https://github.com/WebAssembly/simd/issues/372#issuecomment-722763560) and is demonstrated [here for 8 to 32bit](https://godbolt.org/z/xj6jo7) and [here for 8 to 64 bit](https://godbolt.org/z/xfE9zb).  There's a lot of room for compiler optimization depending on how the subsequent code operates.  For instance, the primary advantage of the `tbl` approach (on ARM64) is when a mask already exists and doesn't require a load from memory.  In other cases, it may make more sense to go the `ushll` or `sshll` routes.  Whether or not a benefit is achieved depends on port utilization of the subsequent code and how much out of order and instruction-level parallelism that can be obtained.  This does not appear to be the case with x64 chips which appear to gain a benefit so long as the number of shuffles is reduced.  In such cases, if a compiler detects a load followed by a convert, it can immediately optimize it upstream with `movzx****` or `movsx****` directly to the target register.  Such should provide the maximum instruction-level parallelism and minimal port usage.  In any case where performance with this method does not exceed that of incremental conversions, the incremental conversion method may be used in its place.  Similarly, any system or architecture that benefits from this conversion method over that of the incremental conversion method can use any of the masks described herein as if they were constants provided to the existing v128.swizzle operation. 
# Mapping To Common Instruction Sets
This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience. Compliant WebAssembly implementations do not have to follow the same code generation patterns.
## Masks or Tables relevant to x64 and ARM Implementations
```


    mask_i32x4_i8x16_u0 = [0,255,255,255,
                           1,255,255,255,
                           2,255,255,255,
                           3,255,255,255]
    mask_i32x4_i8x16_u1 = [4,255,255,255,
                           5,255,255,255,
                           6,255,255,255,
                           7,255,255,255]
    mask_i32x4_i8x16_u2 = [8,255,255,255,
                           9,255,255,255,
                           10,255,255,255,
                           11,255,255,255]
    mask_i32x4_i8x16_u3 = [12,255,255,255,
                           13,255,255,255,
                           14,255,255,255,
                           15,255,255,255]
    mask_i32x4_i8x16_s0 = [255,255,255,0,
                           255,255,255,1,
                           255,255,255,2,
                           255,255,255,3]
    mask_i32x4_i8x16_s1 = [255,255,255,4,
                           255,255,255,5,
                           255,255,255,6,
                           255,255,255,7]
    mask_i32x4_i8x16_s2 = [255,255,255,8,
                           255,255,255,9,
                           255,255,255,10,
                           255,255,255,11]
    mask_i32x4_i8x16_s3 = [255,255,255,12
                           255,255,255,13
                           255,255,255,14
                           255,255,255,15]
```

<details>
   <summary>Withdrawn lowerings</summary>

```
    mask_i64x2_i8x16_u0 = [0,255,255,255,255,255,255,255,
                           1,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u1 = [2,255,255,255,255,255,255,255,
                           3,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u2 = [4,255,255,255,255,255,255,255,
                           5,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u3 = [6,255,255,255,255,255,255,255,
                           7,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u4 = [8,255,255,255,255,255,255,255,
                           9,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u5 = [10,255,255,255,255,255,255,255,
                           11,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u6 = [12,255,255,255,255,255,255,255,
                           13,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_u7 = [14,255,255,255,255,255,255,255,
                           15,255,255,255,255,255,255,255]
    mask_i64x2_i8x16_s0 = [255,255,255,255,255,255,255,0
                           255,255,255,255,255,255,255,1]
    mask_i64x2_i8x16_s1 = [255,255,255,255,255,255,255,2,
                           255,255,255,255,255,255,255,3]
    mask_i64x2_i8x16_s2 = [255,255,255,255,255,255,255,4,
                           255,255,255,255,255,255,255,5]
    mask_i64x2_i8x16_s3 = [255,255,255,255,255,255,255,6,
                           255,255,255,255,255,255,255,7]
    mask_i64x2_i8x16_s4 = [255,255,255,255,255,255,255,8,
                           255,255,255,255,255,255,255,9]
    mask_i64x2_i8x16_s5 = [255,255,255,255,255,255,255,10,
                           255,255,255,255,255,255,255,11]
    mask_i64x2_i8x16_s6 = [255,255,255,255,255,255,255,12,
                           255,255,255,255,255,255,255,13]
    mask_i64x2_i8x16_s7 = [255,255,255,255,255,255,255,14,
                           255,255,255,255,255,255,255,15]
    mask_i64x2_i16x8_u0 =  [0,1,255,255,255,255,255,255,
                           2,3,255,255,255,255,255,255]
    mask_i64x2_i16x8_u1 =  [4,5,255,255,255,255,255,255,
                           6,7,255,255,255,255,255,255]
    mask_i64x2_i16x8_u2 =  [8,9,255,255,255,255,255,255,
                           10,11,255,255,255,255,255,255]
    mask_i64x2_i16x8_u3 =  [12,13,255,255,255,255,255,255,
                           14,15,255,255,255,255,255,255]
    mask_i64x2_i16x8_s0 =  [255,255,255,255,255,255,0,1,
                           255,255,255,255,255,255,2,3]
    mask_i64x2_i16x8_s1 =  [255,255,255,255,255,255,4,5,
                           255,255,255,255,255,255,6,7]
    mask_i64x2_i16x8_s2 =  [255,255,255,255,255,255,8,9,
                           255,255,255,255,255,255,10,11]
    mask_i64x2_i16x8_s3 =  [255,255,255,255,255,255,12,13,
                           255,255,255,255,255,255,14,15]

    mask_i64x2_i8x16_condensed_s0 =  [255,255,255,0,255,255,255,1,255,255,255,2,255,255,255,3]
    mask_i64x2_i8x16_condensed_s1 = [255,255,255,4,255,255,255,5,255,255,255,6,255,255,255,7]
    mask_i64x2_i8x16_condensed_s2  = [255,255,255,8,255,255,255,9,255,255,255,10,255,255,255,11]
    mask_i64x2_i8x16_condensed_s3 =  [255,255,255,12,255,255,255,13,255,255,255,14,255,255,255,15]

    mask_i64x2_i16x8_condensed_s0 =  [255,255,0,1,255,255,2,3,255,255,4,5,255,255,6,7]
    mask_i64x2_i16x8_condensed_s1 = [255,255,8,9,255,255,10,11,255,255,12,13,255,255,14,15]

   *255 can be replaced with 128 where necessary or reasonable.*
```

</details>
     
## x86/x86-64 processors with AVX instruction set
### i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# When c=0
        vpmovzxbd xmm_out, xmm_a # for mask c=0
# When c=1
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_u1 
# When c=2
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_u2 
# When c=3
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_u3 
```
### i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# When c=0
        vpmovsxbd xmm_out, xmm_a # for mask c=0
# When c=1
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_s1
        vpsrad   xmm_out, xmm_out, 24 
# When c=2
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_s2
        vpsrad   xmm_out, xmm_out, 24 
# When c=3
        vpshufb  xmm_out, xmm_a, mask_i32x4_i8x16_s3
        vpsrad   xmm_out, xmm_out, 24 
```
<details>
<summary>Withdrawn lowerings </summary>

### i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# When c=0
        vpmovzxbq xmm_out, xmm_a 
# When c=1..7
        vpshufb  xmm_out, xmm_a, mask_i64x2_i8x16_u$c 
```
### i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# When c=0
        vpmovsxbq xmm_out, xmm_a 
# When c=1
        vpsrad xmm_out, xmm_a, 16
        vpmovsxbq xmm_out, xmm_out
# When c=[1,3,5,7]
        vpshufb xmm_tmp, xmm_a, mask_i64x2_i8x16_condensed_s$(c-1)
        vpsrad  xmm_out, xmm_tmp, 24
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckhdq      xmm_out, xmm_out, xmm_tmp 
# When c=[2,4,6]      
        vpshufb xmm_tmp, xmm_a, mask_i64x2_i8x16_condensed_s$(c)
        vpsrad  xmm_out, xmm_tmp, 24
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckldq      xmm_out, xmm_out, xmm_tmp 

```
### i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# When c=0
        vpmovzxwq xmm_out, xmm_a 
# When c=1..3
        vpshufb  xmm_out, xmm_a, mask_i64x2_i16x8_u$c 
```
### i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# When c=0
        vpmovswbq xmm_out, xmm_a 
# When c=[1,3]
        vpshufb xmm_tmp, xmm_a, mask_i64x2_i8x16_condensed_s$(c-1)
        vpsrad  xmm_out, xmm_tmp, 16
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckhdq      xmm_out, xmm_out, xmm_tmp 
# When c=[2]      
        vpshufb xmm_tmp, xmm_a, mask_i64x2_i8x16_condensed_s$(c)
        vpsrad  xmm_out, xmm_tmp, 16
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckldq      xmm_out, xmm_out, xmm_tmp 
```
</details>

## x86/x86-64 processors with SSE4 instruction set
### i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
        movdqa   xmm_out, xmm_a
# when c=0
       pmovzxbd  xmm_out, xmm_out
# when c=1..3
        pshufb  xmm_out, mask_i32x4_i8x16_u$c
```
### i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
        movdqa   xmm_out, xmm_a
# when c=0
       pmovsxbd  xmm_out, xmm_out
# when c=1..3
        pshufb  xmm_out, mask_i32x4_i8x16_s$c
        psrad   xmm_out, 24
```
<details>
<summary>Withdrawn lowerings</summary>

### i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
```assembly
        movdqa  xmm_out, xmm_a
# when c=0
        pmovsxbq  xmm_out, xmm_out
# when c=1..7
        pshufb  xmm_out, mask_i64x2_i8x16_u$c 
```
### i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# Option 1 (best performance in most cases)
       pmovsxbq xmm_out, mem_argument(base + 2*c)
# Option 2 
# when c=0
       pmovsxbq xmm_out, xmm_a
# when c=1
       movdqa xmm_out, xmm_a
       psrld xmm_out, 16
       pmovsxwq xmm_out, xmm_a
# When c=[1,3,5,7]
        movdqa xmm_tmp, xmm_a
        vpshufb xmm_tmp, mask_i64x2_i8x16_condensed_s$(c-1)
        movdqa xmm_out, xmm_tmp
        vpsrad  xmm_out, xmm_tmp, 24
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckhdq      xmm_out, xmm_out, xmm_tmp 
# When c=[2,4,6]      
        movdqa xmm_tmp, xmm_a
        vpshufb xmm_tmp, mask_i64x2_i8x16_condensed_s$(c-1)
        movdqa xmm_out, xmm_tmp
        vpsrad  xmm_out, xmm_tmp, 24
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckldq      xmm_out, xmm_out, xmm_tmp 
# Option 3 Spill and Load
# This may provide better performance than Option 2 if you're iterating through the whole register
# and you can't optimize for reuse of the original shuffle -- punpck{l,h}dq
      movdqa xmmword ptr[rsp+XXXX], xmm_a
      pmovsxwq xmm_out, dword ptr[rsp+XXXX+2*c]
```
### i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
        movdqa  xmm_out, xmm_a
        pshufb  xmm_out, mask_i64x2_i16x8_u$c 
```
### i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# Option 1 (best performance in most cases)
       pmovsxwq xmm_out, mem_argument(base + 2*c)
# Option 2 
# When c=0
       pmovsxwq xmm_out, xmm_a
# When c=[1,3]
        movdqa xmm_tmp, xmm_a
        vpshufb xmm_tmp, mask_i64x2_i16x8_condensed_s$(c-1)
        movdqa xmm_out, xmm_tmp
        vpsrad  xmm_out, xmm_tmp, 16
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckhdq      xmm_out, xmm_out, xmm_tmp 
# When c=[2]      
        movdqa xmm_tmp, xmm_a
        vpshufb xmm_tmp, mask_i64x2_i16x8_condensed_s$(c)
        movdqa xmm_out, xmm_tmp
        vpsrad  xmm_out, xmm_tmp, 16
        vpsrad  xmm_tmp, xmm_tmp, 31
        vpunpckldq      xmm_out, xmm_out, xmm_tmp 
# when c=1..3 (with just pure random access and no other conversions needed)
       movdqa xmm_out, xmm_a
       psrldq xmm_out, c*4
       pmovsxwq xmm_out, xmm_a
# Option 3 Spill and Load
# This may provide better performance than Option 2 if you're iterating through the whole register
# and you can't optimize for reuse of the original shuffle -- punpck{l,h}dq
      movdqa xmmword ptr[rsp+XXXX], xmm_a
      pmovsxwq xmm_out, dword ptr[rsp+XXXX+2*c]
```
</details>

## x86/x86-64 processors with SSE2 instruction set
### i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# all cases
       pxor         xmm_tmp, xmm_tmp
       movdqa   xmm_out, xmm_a
# case c=0
        punpcklbw       xmm_out, xmm_tmp        
        punpcklwd       xmm_out, xmm_tmp              
 # case c=1
        punpcklbw       xmm_out, xmm_tmp        
        punpckhwd       xmm_out, xmm_tmp 
# case c=2
        punpckhbw       xmm_out, xmm_tmp        
        punpcklwd       xmm_out, xmm_tmp        
# case c=3
        punpckhbw       xmm_out, xmm_tmp        
        punpckhwd       xmm_out, xmm_tmp       
```
### i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# all cases
# xmm_out can be uninitialized since we're discarding the values anyway
# case c=0
        punpcklbw       xmm_out, xmm_a         
        punpcklwd       xmm_out, xmm_out
        psrad               xmm_out, 24
 # case c=1
        punpcklbw       xmm_out, xmm_a         
        punpckhwd       xmm_out, xmm_out
        psrad               xmm_out, 24
# case c=2
        punpckhbw       xmm_out, xmm_a         
        punpcklwd       xmm_out, xmm_out
        psrad               xmm_out, 24
# case c=3
        punpckhbw       xmm_out, xmm_a         
        punpckhwd       xmm_out, xmm_out
        psrad                xmm_out, 24
```
<details>
<summary>Withdrawn lowerings</summary>

### i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# all cases
        movdqa xmm_out, xmm_a
        pxor    xmm_tmp, xmm_tmp
# case c=0
        punpcklbw       xmm_out, xmm_tmp
        punpcklwd       xmm_out, xmm_tmp             
        punpckldq       xmm_out, xmm_tmp           
# case c=1
        punpcklbw       xmm_out, xmm_tmp
        punpcklwd       xmm_out, xmm_tmp             
        punpckhdq       xmm_out, xmm_tmp
# case c=2
        punpcklbw       xmm_out, xmm_tmp
        punpckhwd       xmm_out, xmm_tmp             
        punpckldq       xmm_out, xmm_tmp
# case c=3
        punpcklbw       xmm_out, xmm_tmp
        punpckhwd       xmm_out, xmm_tmp             
        punpckhdq       xmm_out, xmm_tmp
# case c=4..7
# repeat c=0..3 with punpckhbw instead of punpcklbw
```
### i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# LLVM-MCA seems to suggest a spill for these cases if the chip really only supports SSE2
        movaps  xmmword ptr [safe_memory_location], xmm_a
        movsx   r8, byte ptr [safe_memory_location+c*2] # use which ever 64 bit register makes sense
        movsx   rcx, byte ptr [safe_memory_location+c*2+1] # use which ever 64 bit register makes sense
        movq    xmm_tmp, rcx
        movq    xmm_out, r8
        punpcklqdq      xmm_out, xmm_tmp             
```
### i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# all cases
        movdqa xmm_out, xmm_a
        pxor    xmm_tmp, xmm_tmp
# case c=0
        punpcklwd       xmm_out, xmm_tmp             
        punpckldq       xmm_out, xmm_tmp           
# case c=1
        punpcklwd       xmm_out, xmm_tmp             
        punpckhdq       xmm_out, xmm_tmp
# case c=2
        punpckhwd       xmm_out, xmm_tmp             
        punpckldq       xmm_out, xmm_tmp
# case c=3
        punpckhwd       xmm_out, xmm_tmp             
        punpckhdq       xmm_out, xmm_tmp
```
### i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# case c=0
        punpcklwd       xmm_out, xmm_a
        movdqa           xmm_high, xmm_out
        psrad               xmm_out, 16
        psrad               xmm_high, 31            
        punpckldq       xmm_out, xmm_high           
# case c=1
        punpcklwd       xmm_out, xmm_a
        movdqa           xmm_high, xmm_out
        psrad               xmm_out, 16
        psrad               xmm_high, 31            
        punpckhdq       xmm_out, xmm_high        
# case c=2
        punpckhwd       xmm_out, xmm_a
        movdqa           xmm_high, xmm_out
        psrad               xmm_out, 16
        psrad               xmm_high, 31            
        punpckldq       xmm_out, xmm_high       
# case c=3
        punpckhwd       xmm_out, xmm_a
        movdqa           xmm_high, xmm_out
        psrad               xmm_out, 16
        psrad               xmm_high, 31            
        punpckhdq       xmm_out, xmm_high       
```
</details>


## on ARM64
### i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B } mask_i32x4_i8x16_u$c.16B
### Option 2
        ushll{2}    vOut.4S,  vA.{4H,8H}, #0
        ushll{2}    vOut.2D,  vOut.{2S,4S}, #0
```
### i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B } vMask_i64x2_i8x16_s$c.16B
        sshr    vOut.2S, #56
### Option 2
        sshll{2}    vOut.4H, vA.{8B,16B}, #0
        sshll{2}    vOut.4S,  vOut.4H, #0
```
<details>
<summary>Withdrawn lowerings</summary>

### i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B } vMask_i64x2_i8x16_u$c.16B
### Option 2
        ushll{2}    vOut.4H, vA.{8B,16B}, #0
        ushll{2}    vOut.4S,  vOut.{4H,8H}, #0
        ushll{2}    vOut.2D,  vOut.{2S,4S}, #0
```
### i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B }, vMask_i64x2_i8x16_s$c.16B
        sshr    vOut.2S, #56 
### Option 2
        sshll{2}    vOut.4H, vA.{8B,16B}, #0
        sshll{2}    vOut.4S,  vOut.{4H,8H}, #0
        sshll{2}    vOut.2D,  vOut.{2S,4S}, #0
```
### i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B } vMask_i64x2_i16x8_u$c.16B
### Option 2
        ushll{2}    vOut.4S,  vA.{4H,8H}, #0
        ushll{2}    vOut.2D,  vOut.{2S,4S}, #0
```
### i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
### Option 1
        tbl vOut.16B, { vA.16B } vMask_i64x2_i8x16_s$c.16B
        sshr    vOut.2S, #48
### Option 2
        sshll{2}    vOut.4S,  vA.{4H,8H}, #0
        sshll{2}    vOut.2D,  vOut.{2S,4S}, #279 
```
</details>

## on ARMv7 with NEON
### i32x4.widen_i8x16_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# first lower 64 of mask and input vector
# assuming dLow/DHigh correspond to a Q
        tbl dOutLow, { dALow } (mask_i32x4_i8x16_u$c & 0xffffffffffffffff)
# second upper 64 of mask and input vector
        tbl dOutHigh, { dAHigh } (mask_i32x4_i8x16_u$c >> 64)
```
### i32x4.widen_i8x16_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# assuming dLow/DHigh correspond to a Q
# lower 64
        tbl dOutLow, { dALow } (mask_i32x4_i8x16_s$c & 0xffffffffffffffff)
# upper 64
        tbl dOutHigh, { dAHigh } (mask_i32x4_i8x16_s$c >> 64)
        vshr.s64        qOut, qOut, #24
```
<details>
<summary>Withdrawn lowerings</summary>


### i64x2.widen_i8x16_u(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# assuming dLow/DHigh correspond to a Q
# lower 64
        tbl dOutLow, { dALow } (mask_i64x2_i8x16_u$c & 0xffffffffffffffff)
# upper 64
        tbl dOutHigh, { dAHigh } (mask_i64x2_i8x16_u$c >> 64)
```
### i64x2.widen_i8x16_s(v128: a, ImmLaneIdx8: c) -> v128
```assembly
# assuming dLow/DHigh correspond to a Q
# lower 64
        tbl dOutLow, { dALow } (mask_i64x2_i8x16_s$c & 0xffffffffffffffff)
# upper 64
        tbl dOutHigh, { dAHigh } (mask_i64x2_i8x16_s$c >> 64)
        vshr.s64        qOut, qOut, #56
```
### i64x2.widen_i16x8_u(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# assuming dLow/DHigh correspond to a Q
# lower 64
        tbl dOutLow, { dALow } (mask_i64x2_i16x8_u$c & 0xffffffffffffffff)
# upper 64
        tbl dOutHigh, { dAHigh } (mask_i64x2_i16x8_u$c >> 64)
```
### i64x2.widen_i16x8_s(v128: a, ImmLaneIdx4: c) -> v128
```assembly
# assuming dLow/DHigh correspond to a Q
# lower 64
        tbl dOutLow, { dALow } (mask_i64x2_i16x8_s$c & 0xffffffffffffffff)
# upper 64
        tbl dOutHigh, { dAHigh } (mask_i64x2_i16x8_s$c >> 64)
        vshr.s64 qOut, qOut, #48
```
</details>