### PR TITLE
Fix SIMD load splat/extend names in binary and text section of spec

### DIFF
--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -419,16 +419,16 @@ SIMD loads and stores are followed by the encoding of their |memarg| immediate.
    \begin{array}{llclll}
    \production{instruction} & \Binstr &::=& \dots \\&&|&
      \hex{FD}~~0{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD~m \\ &&|&
-     \hex{FD}~~1{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I16X8.\LOAD\K{8x8\_s}~m \\ &&|&
-     \hex{FD}~~2{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I16X8.\LOAD\K{8x8\_u}~m \\ &&|&
-     \hex{FD}~~3{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I32X4.\LOAD\K{16x4\_s}~m \\ &&|&
-     \hex{FD}~~4{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I32X4.\LOAD\K{16x4\_u}~m \\ &&|&
-     \hex{FD}~~5{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I64X2.\LOAD\K{32x2\_s}~m \\ &&|&
-     \hex{FD}~~6{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I64X2.\LOAD\K{32x2\_u}~m \\ &&|&
-     \hex{FD}~~7{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I8X16.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~8{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I16X8.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~9{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I32X4.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~10{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \I64X2.\LOAD\K{\_splat}~m \\ &&|&
+     \hex{FD}~~1{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{8x8\_s}~m \\ &&|&
+     \hex{FD}~~2{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{8x8\_u}~m \\ &&|&
+     \hex{FD}~~3{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{16x4\_s}~m \\ &&|&
+     \hex{FD}~~4{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{16x4\_u}~m \\ &&|&
+     \hex{FD}~~5{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{32x2\_s}~m \\ &&|&
+     \hex{FD}~~6{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{32x2\_u}~m \\ &&|&
+     \hex{FD}~~7{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \hex{FD}~~8{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \hex{FD}~~9{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \hex{FD}~~10{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
      \hex{FD}~~11{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\STORE~m \\
    \end{array}
 

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -425,10 +425,10 @@ SIMD loads and stores are followed by the encoding of their |memarg| immediate.
      \hex{FD}~~4{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{16x4\_u}~m \\ &&|&
      \hex{FD}~~5{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{32x2\_s}~m \\ &&|&
      \hex{FD}~~6{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{32x2\_u}~m \\ &&|&
-     \hex{FD}~~7{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~8{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~9{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \hex{FD}~~10{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \hex{FD}~~7{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{8\_splat}~m \\ &&|&
+     \hex{FD}~~8{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{16\_splat}~m \\ &&|&
+     \hex{FD}~~9{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{32\_splat}~m \\ &&|&
+     \hex{FD}~~10{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\LOAD\K{64\_splat}~m \\ &&|&
      \hex{FD}~~11{:}\Bu32~~m{:}\Bmemarg &\Rightarrow& \V128.\STORE~m \\
    \end{array}
 

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -460,16 +460,16 @@ SIMD memory instructions have optional offset and alignment immediates, like the
    \begin{array}{llclll}
    \production{instruction} & \Tplaininstr_I &::=& \dots \phantom{averylonginstructionnameforsimdtext} && \phantom{simdhasreallylonginstructionnames} \\ &&|&
      \text{v128.load}~~m{:}\Tmemarg_{16} &\Rightarrow& \V128.\LOAD~m \\ &&|&
-     \text{i16x8.load8x8\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_s}~m \\ &&|&
-     \text{i16x8.load8x8\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_u}~m \\ &&|&
-     \text{i32x4.load16x4\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_s}~m \\ &&|&
-     \text{i32x4.load16x4\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_u}~m \\ &&|&
-     \text{i64x2.load32x2\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_s}~m \\ &&|&
-     \text{i64x2.load32x2\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_u}~m \\ &&|&
-     \text{i8x16.load\_splat}~~m{:}\Tmemarg_1 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i16x8.load\_splat}~~m{:}\Tmemarg_2 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i32x4.load\_splat}~~m{:}\Tmemarg_4 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i64x2.load\_splat}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \text{v128.load8x8\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_s}~m \\ &&|&
+     \text{v128.load8x8\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_u}~m \\ &&|&
+     \text{v128.load16x4\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_s}~m \\ &&|&
+     \text{v128.load16x4\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_u}~m \\ &&|&
+     \text{v128.load32x2\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_s}~m \\ &&|&
+     \text{v128.load32x2\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_u}~m \\ &&|&
+     \text{v128.load8\_splat}~~m{:}\Tmemarg_1 &\Rightarrow& \V128.\LOAD\K{8\_splat}~m \\ &&|&
+     \text{v128.load16\_splat}~~m{:}\Tmemarg_2 &\Rightarrow& \V128.\LOAD\K{16\_splat}~m \\ &&|&
+     \text{v128.load32\_splat}~~m{:}\Tmemarg_4 &\Rightarrow& \V128.\LOAD\K{32\_splat}~m \\ &&|&
+     \text{v128.load64\_splat}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{64\_splat}~m \\ &&|&
      \text{v128.store}~~m{:}\Tmemarg_{16} &\Rightarrow& \V128.\STORE~m \\
    \end{array}
 

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -460,16 +460,16 @@ SIMD memory instructions have optional offset and alignment immediates, like the
    \begin{array}{llclll}
    \production{instruction} & \Tplaininstr_I &::=& \dots \phantom{averylonginstructionnameforsimdtext} && \phantom{simdhasreallylonginstructionnames} \\ &&|&
      \text{v128.load}~~m{:}\Tmemarg_{16} &\Rightarrow& \V128.\LOAD~m \\ &&|&
-     \text{i16x8.load8x8\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \I16X8.\LOAD\K{8x8\_s}~m \\ &&|&
-     \text{i16x8.load8x8\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \I16X8.\LOAD\K{8x8\_u}~m \\ &&|&
-     \text{i32x4.load16x4\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \I32X4.\LOAD\K{16x4\_s}~m \\ &&|&
-     \text{i32x4.load16x4\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \I32X4.\LOAD\K{16x4\_u}~m \\ &&|&
-     \text{i64x2.load32x2\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \I64X2.\LOAD\K{32x2\_s}~m \\ &&|&
-     \text{i64x2.load32x2\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \I64X2.\LOAD\K{32x2\_u}~m \\ &&|&
-     \text{i8x16.load\_splat}~~m{:}\Tmemarg_1 &\Rightarrow& \I8X16.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i16x8.load\_splat}~~m{:}\Tmemarg_2 &\Rightarrow& \I16X8.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i32x4.load\_splat}~~m{:}\Tmemarg_4 &\Rightarrow& \I32X4.\LOAD\K{\_splat}~m \\ &&|&
-     \text{i64x2.load\_splat}~~m{:}\Tmemarg_8 &\Rightarrow& \I64X2.\LOAD\K{\_splat}~m \\ &&|&
+     \text{i16x8.load8x8\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_s}~m \\ &&|&
+     \text{i16x8.load8x8\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{8x8\_u}~m \\ &&|&
+     \text{i32x4.load16x4\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_s}~m \\ &&|&
+     \text{i32x4.load16x4\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{16x4\_u}~m \\ &&|&
+     \text{i64x2.load32x2\_s}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_s}~m \\ &&|&
+     \text{i64x2.load32x2\_u}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{32x2\_u}~m \\ &&|&
+     \text{i8x16.load\_splat}~~m{:}\Tmemarg_1 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \text{i16x8.load\_splat}~~m{:}\Tmemarg_2 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \text{i32x4.load\_splat}~~m{:}\Tmemarg_4 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
+     \text{i64x2.load\_splat}~~m{:}\Tmemarg_8 &\Rightarrow& \V128.\LOAD\K{\_splat}~m \\ &&|&
      \text{v128.store}~~m{:}\Tmemarg_{16} &\Rightarrow& \V128.\STORE~m \\
    \end{array}
 


### PR DESCRIPTION
Follow up to #297 for renaming the instructions in binary and text
sections in the spec.