### PR TITLE
i64x2.min_s and i64x2.max_s instructions

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -191,6 +191,8 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i64x2.add`                 |    `0xce`| -                        |
 | `i64x2.sub`                 |    `0xd1`| -                        |
 | `i64x2.mul`                 |    `0xd5`| -                        |
+| `i64x2.min_s`               |    `0xd6`| -                        |
+| `i64x2.max_s`               |    `0xd8`| -                        |
 | `f32x4.ceil`                |    `0xd8`| -                        |
 | `f32x4.floor`               |    `0xd9`| -                        |
 | `f32x4.trunc`               |    `0xda`| -                        |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -160,6 +160,8 @@
 | `i64x2.widen_high_i32x4_s`  |                           |                    |                    |                    |                    |
 | `i64x2.widen_low_i32x4_u`   |                           |                    |                    |                    |                    |
 | `i64x2.widen_high_i32x4_u`  |                           |                    |                    |                    |                    |
+| `i64x2.min_s`               |                           |                    |                    |                    |                    |
+| `i64x2.max_s`               |                           |                    |                    |                    |                    |
 | `f32x4.abs`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `f32x4.sqrt`                |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -102,9 +102,9 @@
 | i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | -------------            | 0xd3   |
 | -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | -------------            | 0xd4   |
 | ---- mul ----        | 0x75   | i16x8.mul                | 0x95   | i32x4.mul                | 0xb5   | i64x2.mul                | 0xd5   |
-| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | -------------            | 0xd6   |
+| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | i64x2.min_s              | 0xd6   |
 | i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | -------------            | 0xd7   |
-| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | -------------            | 0xd8   |
+| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | i64x2.max_s              | 0xd8   |
 | i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | -------------            | 0xd9   |
 | ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | -------------            | 0xda   |
 | i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | -------------            | 0xdb   |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -529,6 +529,7 @@ def S.q15mulr_sat_s(a, b):
 * `i16x8.min_u(a: v128, b: v128) -> v128`
 * `i32x4.min_s(a: v128, b: v128) -> v128`
 * `i32x4.min_u(a: v128, b: v128) -> v128`
+* `i64x2.min_s(a: v128, b: v128) -> v128`
 
 Compares lane-wise signed/unsigned integers, and returns the minimum of
 each pair.
@@ -545,6 +546,7 @@ def S.min(a, b):
 * `i16x8.max_u(a: v128, b: v128) -> v128`
 * `i32x4.max_s(a: v128, b: v128) -> v128`
 * `i32x4.max_u(a: v128, b: v128) -> v128`
+* `i64x2.max_s(a: v128, b: v128) -> v128`
 
 Compares lane-wise signed/unsigned integers, and returns the maximum of
 each pair.


### PR DESCRIPTION
Introduction
=========

This is proposal to add 64-bit variant of the existing `min_s` and `max_s` instructions. Only x86 processors with AVX512 natively support these instructions, but ARMv7 NEON, ARM64 and x86 with SSE4.2 or AVX can efficiently emulate them with 2-4 instructions.

Applications
=========

- [.Net runtime](https://github.com/dotnet/runtime/blob/69e114c1abf91241a0eeecf1ecceab4711b8aa62/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX512.int64_t.generated.h#L46)
- [KFR DSP framework](https://github.com/kfrlib/kfr/blob/55e8c107122016518884e07ebe6b21704b27cb31/include/kfr/math/impl/min_max.hpp#L85)
- [Vector Class library](https://github.com/vectorclass/version2/blob/bbb95859eeaf7cd92674166bbcf4ab083acd04ee/vectori512.h#L1060-L1068)
- [xsimd SIMD wrapper library](https://github.com/xtensor-stack/xsimd/blob/4dd2482908de2e90aa6b9ad004ae90036216a945/include/xsimd/types/xsimd_avx512_int64.hpp#L344)
- [simdpp SIMD wrapper library](https://github.com/p12tic/libsimdpp/blob/9dac213d6965bf57c7accf9dda6d16c3bed0e3ac/simdpp/detail/insn/i_max.h#L316)
- [JASS search engine](https://github.com/andrewtrotman/JASSv2/blob/13343448c648a762b1ead4cc0a57da5ccfcf1d69/source/sort512_uint64_t.h#L66)

Mapping to Common Instruction Sets
===========================

This section illustrates how the new WebAssembly instructions can be lowered on common instruction sets. However, these patterns are provided only for convenience, compliant WebAssembly implementations do not have to follow the same code generation patterns.

x86/x86-64 processors with AVX512F and AVX512VL instruction sets
--------------------------------------------------

- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` is lowered to `VPMINSQ xmm_y, xmm_a, xmm_b`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` is lowered to `VPMAXSQ xmm_y, xmm_a, xmm_b`

x86/x86-64 processors with AVX instruction set
--------------------------------------------------

- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `VPCMPGTQ xmm_y, xmm_a, xmm_b`
    - `VPBLENDVB xmm_y, xmm_a, xmm_b, xmm_y`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `VPCMPGTQ xmm_y, xmm_a, xmm_b`
    - `VPBLENDVB xmm_y, xmm_b, xmm_a, xmm_y`

x86/x86-64 processors with SSE4.2 instruction set
--------------------------------------------------
- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `b` and `a`/`b`/`y` are **not** in `xmm0`) is lowered to:
    - `MOVDQA xmm0, xmm_a`
    - `MOVDQA xmm_y, xmm_a`
    - `PCMPGTQ xmm0, xmm_b`
    - `PBLENDVB xmm_y, xmm_b`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `a`/`b`/`y` are **not** in `xmm0`) is lowered to:
    - `MOVDQA xmm0, xmm_a`
    - `MOVDQA xmm_y, xmm_b`
    - `PCMPGTQ xmm0, xmm_b`
    - `PBLENDVB xmm_y, xmm_a`

x86/x86-64 processors with SSE4.1 instruction set
--------------------------------------------------

Based on [this answer](https://stackoverflow.com/a/65175746) by user aqrit on Stack Overflow

- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `a` and `y` is **not** `b` and `a`/`b`/`y` are **not** in `xmm0`) is lowered to:
    - `MOVDQA xmm0, xmm_b`
    - `MOVDQA xmm_y, xmm_a`
    - `PSUBQ xmm0, xmm_a`
    - `PCMPEQD xmm_y, xmm_b`
    - `PAND xmm0, xmm_y`
    - `MOVDQA xmm_y, xmm_a`
    - `PCMPGTD xmm_y, xmm_b`
    - `POR xmm0, xmm_y`
    - `MOVDQA xmm_y, xmm_a`
    - `PSHUFD xmm0, xmm0, 0xF5`
    - `PBLENDVB xmm_y, xmm_b`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `y` is **not** `b` and `a`/`b`/`y` are **not** in `xmm0`) is lowered to:
    - `MOVDQA xmm0, xmm_b`
    - `MOVDQA xmm_y, xmm_a`
    - `PSUBQ xmm0, xmm_a`
    - `PCMPEQD xmm_y, xmm_b`
    - `PAND xmm0, xmm_y`
    - `MOVDQA xmm_y, xmm_a`
    - `PCMPGTD xmm_y, xmm_b`
    - `POR xmm0, xmm_y`
    - `MOVDQA xmm_y, xmm_b`
    - `PSHUFD xmm0, xmm0, 0xF5`
    - `PBLENDVB xmm_y, xmm_a`

x86/x86-64 processors with SSE2 instruction set
--------------------------------------------------

Based on [this answer](https://stackoverflow.com/a/65175746) by user aqrit on Stack Overflow

- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `MOVDQA xmm_y, xmm_b`
    - `MOVDQA xmm_tmp, xmm_a`
    - `PSUBQ xmm_y, xmm_a`
    - `PCMPEQD xmm_tmp, xmm_b`
    - `PAND xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_a`
    - `PCMPGTD xmm_tmp, xmm_b`
    - `POR xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_b`
    - `PSHUFD xmm_y, xmm_y, 0xF5`
    - `PAND xmm_tmp, xmm_y`
    - `PANDN xmm_y, xmm_a`
    - `POR xmm_y, xmm_tmp`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `MOVDQA xmm_y, xmm_b`
    - `MOVDQA xmm_tmp, xmm_a`
    - `PSUBQ xmm_y, xmm_a`
    - `PCMPEQD xmm_tmp, xmm_b`
    - `PAND xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_a`
    - `PCMPGTD xmm_tmp, xmm_b`
    - `POR xmm_y, xmm_tmp`
    - `MOVDQA xmm_tmp, xmm_a`
    - `PSHUFD xmm_y, xmm_y, 0xF5`
    - `PAND xmm_tmp, xmm_y`
    - `PANDN xmm_y, xmm_b`
    - `POR xmm_y, xmm_tmp`

ARM64 processors
--------------------------------------------------
- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `CMGT Vy.2D, Va.2D, Vb.2D`
    - `BSL Vy.16B, Vb.16B, Va.16B`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `CMGT Vy.2D, Va.2D, Vb.2D`
    - `BSL Vy.16B, Va.16B, Vb.16B`

ARMv7 processors with NEON instruction set
--------------------------------------------------

Based on [this answer](https://stackoverflow.com/a/65223269) by user aqrit on Stack Overflow

- **i64x2.min_s**
  - `y = i64x2.min_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `VQSUB.S64 Qy, Qb, Qa`
    - `VSHR.S64 Qy, Qy, #63`
    - `VBSL Qy, Qb, Qa`
- **i64x2.max_s**
  - `y = i64x2.max_s(a, b)` (`y` is **not** `a` and `y` is **not** `b`) is lowered to:
    - `VQSUB.S64 Qy, Qb, Qa`
    - `VSHR.S64 Qy, Qy, #63`
    - `VBSL Qy, Qa, Qb`
