### PR TITLE
Replace i8x16/i16x8/i32x4.any_true with v128.any_true

### DIFF
--- a/proposals/simd/BinarySIMD.md
+++ b/proposals/simd/BinarySIMD.md
@@ -117,7 +117,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `v128.bitselect`            |    `0x52`| -                  |
 | `i8x16.abs`                 |    `0x60`| -                  |
 | `i8x16.neg`                 |    `0x61`| -                  |
-| `i8x16.any_true`            |    `0x62`| -                  |
 | `i8x16.all_true`            |    `0x63`| -                  |
 | `i8x16.bitmask`             |    `0x64`| -                  |
 | `i8x16.narrow_i16x8_s`      |    `0x65`| -                  |
@@ -138,7 +137,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i8x16.avgr_u`              |    `0x7b`| -                  |
 | `i16x8.abs`                 |    `0x80`| -                  |
 | `i16x8.neg`                 |    `0x81`| -                  |
-| `i16x8.any_true`            |    `0x82`| -                  |
 | `i16x8.all_true`            |    `0x83`| -                  |
 | `i16x8.bitmask`             |    `0x84`| -                  |
 | `i16x8.narrow_i32x4_s`      |    `0x85`| -                  |
@@ -164,7 +162,6 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i16x8.avgr_u`              |    `0x9b`| -                  |
 | `i32x4.abs`                 |    `0xa0`| -                  |
 | `i32x4.neg`                 |    `0xa1`| -                  |
-| `i32x4.any_true`            |    `0xa2`| -                  |
 | `i32x4.all_true`            |    `0xa3`| -                  |
 | `i32x4.bitmask`             |    `0xa4`| -                  |
 | `i32x4.widen_low_i16x8_s`   |    `0xa7`| -                  |
@@ -243,3 +240,4 @@ For example, `ImmLaneIdx16` is a byte with values in the range 0-15 (inclusive).
 | `i64x2.extmul_low_i32x4_u`  |   `0x11a`| -                  |
 | `i64x2.extmul_high_i32x4_u` |   `0x11b`| -                  |
 | `i16x8.q15mulr_sat_s`       |     `TBD`| -                  |
+| `v128.any_true`             |     `TBD`| -                  |

--- a/proposals/simd/ImplementationStatus.md
+++ b/proposals/simd/ImplementationStatus.md
@@ -85,7 +85,6 @@
 | `v128.bitselect`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.abs`                 |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i8x16.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
-| `i8x16.any_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.all_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i8x16.bitmask`             | `-munimplemented-simd128` | :heavy_check_mark: [6] |                |                    | :heavy_check_mark: |
 | `i8x16.narrow_i16x8_s`      |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -106,7 +105,6 @@
 | `i8x16.avgr_u`              |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.abs`                 |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i16x8.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
-| `i16x8.any_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.all_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i16x8.bitmask`             | `-munimplemented-simd128` | :heavy_check_mark: [6] |                |                    | :heavy_check_mark: |
 | `i16x8.narrow_i32x4_s`      |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -133,7 +131,6 @@
 | `i16x8.q15mulr_sat_s`       |                           |                    |                    |                    |                    |
 | `i32x4.abs`                 |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
 | `i32x4.neg`                 |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
-| `i32x4.any_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.all_true`            |               `-msimd128` | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | `i32x4.bitmask`             | `-munimplemented-simd128` | :heavy_check_mark: [6] |                |                    | :heavy_check_mark: |
 | `i32x4.widen_low_i16x8_s`   |               `-msimd128` | :heavy_check_mark: |                    |                    | :heavy_check_mark: |
@@ -211,6 +208,7 @@
 | `i64x2.extmul_high_i32x4_s` |                           |                    |                    |                    |                    |
 | `i64x2.extmul_low_i32x4_u`  |                           |                    |                    |                    |                    |
 | `i64x2.extmul_high_i32x4_u` |                           |                    |                    |                    |                    |
+| `v128.any_true`             |                           |                    |                    |                    |                    |
 
 [1] Tip of tree LLVM as of May 20, 2020
 

--- a/proposals/simd/NewOpcodes.md
+++ b/proposals/simd/NewOpcodes.md
@@ -80,13 +80,13 @@
 
 | i8x16 Op             | opcode | i16x8 Op                 | opcode | i32x4 Op                 | opcode | i64x2 Op                 | opcode |
 | -------------------- | ------ | ------------------------ | ------ | ------------------------ | ------ | ------------------------ | ------ |
-| i8x16.abs            | 0x60   | i16x8.abs                | 0x80   | i32x4.abs                | 0xa0   | ----                     | 0xc0   |
+| i8x16.abs            | 0x60   | i16x8.abs                | 0x80   | i32x4.abs                | 0xa0   | -------------            | 0xc0   |
 | i8x16.neg            | 0x61   | i16x8.neg                | 0x81   | i32x4.neg                | 0xa1   | i64x2.neg                | 0xc1   |
-| i8x16.any_true       | 0x62   | i16x8.any_true           | 0x82   | i32x4.any_true           | 0xa2   | ----                     | 0xc2   |
-| i8x16.all_true       | 0x63   | i16x8.all_true           | 0x83   | i32x4.all_true           | 0xa3   | ----                     | 0xc3   |
+| -------------        | 0x62   | -------------            | 0x82   | -------------            | 0xa2   | -------------            | 0xc2   |
+| i8x16.all_true       | 0x63   | i16x8.all_true           | 0x83   | i32x4.all_true           | 0xa3   | -------------            | 0xc3   |
 | i8x16.bitmask        | 0x64   | i16x8.bitmask            | 0x84   | i32x4.bitmask            | 0xa4   | i64x2.bitmask            | 0xc4   |
-| i8x16.narrow_i16x8_s | 0x65   | i16x8.narrow_i32x4_s     | 0x85   | ---- narrow ----         | 0xa5   | ----                     | 0xc5   |
-| i8x16.narrow_i16x8_u | 0x66   | i16x8.narrow_i32x4_u     | 0x86   | ---- narrow ----         | 0xa6   | ----                     | 0xc6   |
+| i8x16.narrow_i16x8_s | 0x65   | i16x8.narrow_i32x4_s     | 0x85   | ---- narrow ----         | 0xa5   | -------------            | 0xc5   |
+| i8x16.narrow_i16x8_u | 0x66   | i16x8.narrow_i32x4_u     | 0x86   | ---- narrow ----         | 0xa6   | -------------            | 0xc6   |
 | ---- widen ----      | 0x67   | i16x8.widen_low_i8x16_s  | 0x87   | i32x4.widen_low_i16x8_s  | 0xa7   | i64x2.widen_low_i32x4_s  | 0xc7   |
 | ---- widen ----      | 0x68   | i16x8.widen_high_i8x16_s | 0x88   | i32x4.widen_high_i16x8_s | 0xa8   | i64x2.widen_high_i32x4_s | 0xc8   |
 | ---- widen ----      | 0x69   | i16x8.widen_low_i8x16_u  | 0x89   | i32x4.widen_low_i16x8_u  | 0xa9   | i64x2.widen_low_i32x4_u  | 0xc9   |
@@ -95,19 +95,19 @@
 | i8x16.shr_s          | 0x6c   | i16x8.shr_s              | 0x8c   | i32x4.shr_s              | 0xac   | i64x2.shr_s              | 0xcc   |
 | i8x16.shr_u          | 0x6d   | i16x8.shr_u              | 0x8d   | i32x4.shr_u              | 0xad   | i64x2.shr_u              | 0xcd   |
 | i8x16.add            | 0x6e   | i16x8.add                | 0x8e   | i32x4.add                | 0xae   | i64x2.add                | 0xce   |
-| i8x16.add_sat_s      | 0x6f   | i16x8.add_sat_s          | 0x8f   | ---- add_sat ----        | 0xaf   | ----                     | 0xcf   |
-| i8x16.add_sat_u      | 0x70   | i16x8.add_sat_u          | 0x90   | ---- add_sat ----        | 0xb0   | ----                     | 0xd0   |
+| i8x16.add_sat_s      | 0x6f   | i16x8.add_sat_s          | 0x8f   | ---- add_sat ----        | 0xaf   | -------------            | 0xcf   |
+| i8x16.add_sat_u      | 0x70   | i16x8.add_sat_u          | 0x90   | ---- add_sat ----        | 0xb0   | -------------            | 0xd0   |
 | i8x16.sub            | 0x71   | i16x8.sub                | 0x91   | i32x4.sub                | 0xb1   | i64x2.sub                | 0xd1   |
-| i8x16.sub_sat_s      | 0x72   | i16x8.sub_sat_s          | 0x92   | ---- sub_sat ----        | 0xb2   | ----                     | 0xd2   |
-| i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | ----                     | 0xd3   |
-| -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | ----                     | 0xd4   |
+| i8x16.sub_sat_s      | 0x72   | i16x8.sub_sat_s          | 0x92   | ---- sub_sat ----        | 0xb2   | -------------            | 0xd2   |
+| i8x16.sub_sat_u      | 0x73   | i16x8.sub_sat_u          | 0x93   | ---- sub_sat ----        | 0xb3   | -------------            | 0xd3   |
+| -------------        | 0x74   | -------------            | 0x94   | -------------            | 0xb4   | -------------            | 0xd4   |
 | ---- mul ----        | 0x75   | i16x8.mul                | 0x95   | i32x4.mul                | 0xb5   | i64x2.mul                | 0xd5   |
-| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | ----                     | 0xd6   |
-| i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | ----                     | 0xd7   |
-| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | ----                     | 0xd8   |
-| i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | ----                     | 0xd9   |
-| ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | ----                     | 0xda   |
-| i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | ----                     | 0xdb   |
+| i8x16.min_s          | 0x76   | i16x8.min_s              | 0x96   | i32x4.min_s              | 0xb6   | -------------            | 0xd6   |
+| i8x16.min_u          | 0x77   | i16x8.min_u              | 0x97   | i32x4.min_u              | 0xb7   | -------------            | 0xd7   |
+| i8x16.max_s          | 0x78   | i16x8.max_s              | 0x98   | i32x4.max_s              | 0xb8   | -------------            | 0xd8   |
+| i8x16.max_u          | 0x79   | i16x8.max_u              | 0x99   | i32x4.max_u              | 0xb9   | -------------            | 0xd9   |
+| ----------------     | 0x7a   | ----------------         | 0x9a   | i32x4.dot_i16x8_s        | 0xba   | -------------            | 0xda   |
+| i8x16.avgr_u         | 0x7b   | i16x8.avgr_u             | 0x9b   | ---- avgr_u ----         | 0xbb   | -------------            | 0xdb   |
 
 | f32x4 Op        | opcode | f64x2 Op        | opcode |
 | --------------- | ------ | --------------- | ------ |

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -668,20 +668,10 @@ rather than selecting bits controlled by a control mask vector.
 These operations reduce all the lanes of an integer vector to a single scalar
 0 or 1 value. A lane is considered "true" if it is non-zero.
 
-### Any lane true
-* `i8x16.any_true(a: v128) -> i32`
-* `i16x8.any_true(a: v128) -> i32`
-* `i32x4.any_true(a: v128) -> i32`
+### Any bit true
+* `v128.any_true(a: v128) -> i32`
 
-These functions return 1 if any lane in `a` is non-zero, 0 otherwise.
-
-```python
-def S.any_true(a):
-    for i in range(S.Lanes):
-        if a[i] != 0:
-            return 1
-    return 0
-```
+These functions return 1 if any bit in `a` is non-zero, 0 otherwise.
 
 ### All lanes true
 * `i8x16.all_true(a: v128) -> i32`


### PR DESCRIPTION
This patch implements the proposal #416 to make `any_true` instruction untyped as semantically its operation is independent of lane types.