### PR TITLE
Run simd test cases with make partest

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -113,7 +113,7 @@ $(WINMAKE):	clean
 # Executing test suite
 
 TESTDIR =	../test/core
-TESTFILES =	$(shell cd $(TESTDIR); ls *.wast)
+TESTFILES =	$(shell cd $(TESTDIR); ls *.wast; ls simd/*.wast)
 TESTS =		$(TESTFILES:%.wast=%)
 
 .PHONY:		test debugtest partest
@@ -138,7 +138,7 @@ partest: 	$(TESTS:%=quiettest/%)
 
 quiettest/%:	$(OPT)
 		@ ( \
-		  $(TESTDIR)/run.py 2>$(@F).out --wasm `pwd`/$(OPT) $(if $(JS),--js '$(JS)',) $(@F:%=$(TESTDIR)/%.wast) && \
+		  $(TESTDIR)/run.py 2>$(@F).out --wasm `pwd`/$(OPT) $(if $(JS),--js '$(JS)',) $(@:quiettest/%=$(TESTDIR)/%.wast) && \
 		  rm $(@F).out \
 		) || \
 		cat $(@F).out || rm $(@F).out || exit 1

--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -113,7 +113,7 @@ $(WINMAKE):	clean
 # Executing test suite
 
 TESTDIR =	../test/core
-TESTFILES =	$(shell cd $(TESTDIR); ls *.wast; ls simd/*.wast)
+TESTFILES =	$(shell cd $(TESTDIR); ls *.wast; ls */*.wast)
 TESTS =		$(TESTFILES:%.wast=%)
 
 .PHONY:		test debugtest partest


### PR DESCRIPTION
We list all simd test cases in simd/* in TESTFILES, then tweak the
substitution in quiettest to strip quiettest/ from the front of the
target, rather than match on just the file name (which loses the simd/)
prefix.

The temp output file name is unchanged, it uses the base file name (no
simd/ prefix).