### PR TITLE
[spectext] Add i64x2.widen_{low,high}_i32x4_{s,u} to syntax

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -234,8 +234,10 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{i16x8.}\NARROW\K{\_i32x4\_}\sx \\&&|&
      \K{i16x8.}\WIDEN\K{\_low}\K{\_i8x16\_}\sx ~|~
      \K{i32x4.}\WIDEN\K{\_low}\K{\_i16x8\_}\sx \\&&|&
+     \K{i64x2.}\WIDEN\K{\_low}\K{\_i32x4\_}\sx \\&&|&
      \K{i16x8.}\WIDEN\K{\_high}\K{\_i8x16\_}\sx ~|~
      \K{i32x4.}\WIDEN\K{\_high}\K{\_i16x8\_}\sx \\&&|&
+     \K{i64x2.}\WIDEN\K{\_high}\K{\_i32x4\_}\sx \\&&|&
      \ishape\K{.}\vshiftop \\&&|&
      \ishape\K{.}\vibinop \\&&|&
      \K{i8x16.}\viminmaxop ~|~


### PR DESCRIPTION
This is a simple change, validation and execution is already
shape-agnostic, so we only need to add it to the syntax.

Instructions were merged in #290.