### PR TITLE
Skip _output directory when listing wast files for test.

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -114,7 +114,7 @@ $(WINMAKE):	clean
 
 TESTDIR =	../test/core
 # Skip _output directory, since that's a tmp directory, and list all other wast files.
-TESTFILES =	$(shell cd $(TESTDIR); find . -name _output -prune -o -name '*.wast' -print)
+TESTFILES =	$(shell cd $(TESTDIR); ls *.wast; ls [a-z]*/*.wast)
 TESTS =		$(TESTFILES:%.wast=%)
 
 .PHONY:		test debugtest partest

--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -113,7 +113,8 @@ $(WINMAKE):	clean
 # Executing test suite
 
 TESTDIR =	../test/core
-TESTFILES =	$(shell cd $(TESTDIR); ls *.wast; ls */*.wast)
+# Skip _output directory, since that's a tmp directory, and list all other wast files.
+TESTFILES =	$(shell cd $(TESTDIR); find . -name _output -prune -o -name '*.wast' -print)
 TESTS =		$(TESTFILES:%.wast=%)
 
 .PHONY:		test debugtest partest


### PR DESCRIPTION
Follow-up to #434.
Now `make partest && make partest` shouldn't fail.