### PR TITLE
[spectext] Add i8x16.popcnt to syntax

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -226,7 +226,8 @@ SIMD instructions provide basic operations over :ref:`values <syntax-value>` of 
      \K{i8x16.}\viunop ~|~
      \K{i16x8.}\viunop ~|~
      \K{i32x4.}\viunop \\&&|&
-     \K{i64x2.}\NEG \\&&|&
+     \K{i8x16.}\VPOPCNT \\&&|&
+     \K{i64x2.}\VNEG \\&&|&
      \fshape\K{.}\vfunop \\&&|&
      \ishape\K{.}\vitestop \\ &&|&
      \ishape\K{.}\BITMASK \\ &&|&
@@ -365,7 +366,7 @@ Occasionally, it is convenient to group operators together according to the foll
    \production{unary operator} & \vunop &::=&
      \viunop ~|~
      \vfunop ~|~
-     \VNEG \\
+     \VPOPCNT \\
    \production{binary operator} & \vbinop &::=&
      \vibinop ~|~ \vfbinop \\&&|&
      \virelop ~|~ \vfrelop \\&&|&

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -407,6 +407,7 @@
 .. |VGE| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{ge}}
 .. |VABS| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{abs}}
 .. |VNEG| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{neg}}
+.. |VPOPCNT| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{popcnt}}
 .. |ANYTRUE| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{any\_true}}
 .. |ALLTRUE| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{all\_true}}
 .. |BITMASK| mathdef:: \xref{syntax/instructions}{syntax-instr-simd}{\K{bitmask}}


### PR DESCRIPTION
It maps nicely to the existing vunop group, so the validation and
execution semantics are taken care of.

Drive-by fixes:

  - was using NEG instead of VNEG for SIMD negation instruction
  - vunop includes neg twice, since viunop already includes neg.