### PR TITLE
Fix a typo in the f64x2.{pmin,pmax} binary spec

### DIFF
--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -69,7 +69,7 @@ Control Instructions
    The |ELSE| opcode :math:`\hex{05}` in the encoding of an |IF| instruction can be omitted if the following instruction sequence is empty.
 
    Unlike any :ref:`other occurrence <binary-typeidx>`, the :ref:`type index <syntax-typeidx>` in a :ref:`block type <syntax-blocktype>` is encoded as a positive :ref:`signed integer <syntax-sint>`, so that its |SignedLEB128| bit pattern cannot collide with the encoding of :ref:`value types <binary-valtype>` or the special code :math:`\hex{40}`, which correspond to the LEB128 encoding of negative integers.
-   To avoid any loss in the range of allowed indices, it is treated as a 33 bit signed integer. 
+   To avoid any loss in the range of allowed indices, it is treated as a 33 bit signed integer.
 
    In future versions of WebAssembly, the zero byte occurring in the encoding
    of the |CALLINDIRECT| instruction may be used to index additional tables.
@@ -760,8 +760,8 @@ All other SIMD instructions are plain opcodes without any immediates.
      \hex{FD}~~243{:}\Bu32 &\Rightarrow& \F64X2.\VDIV \\ &&|&
      \hex{FD}~~244{:}\Bu32 &\Rightarrow& \F64X2.\VMIN \\ &&|&
      \hex{FD}~~245{:}\Bu32 &\Rightarrow& \F64X2.\VMAX \\ &&|&
-     \hex{FD}~~245{:}\Bu32 &\Rightarrow& \F64X2.\VPMIN \\ &&|&
-     \hex{FD}~~246{:}\Bu32 &\Rightarrow& \F64X2.\VPMAX \\
+     \hex{FD}~~246{:}\Bu32 &\Rightarrow& \F64X2.\VPMIN \\ &&|&
+     \hex{FD}~~247{:}\Bu32 &\Rightarrow& \F64X2.\VPMAX \\
    \end{array}
 
 .. math::


### PR DESCRIPTION
It looks like these have a typo in copying them over from
`BinarySIMD.md`