### PR TITLE
Comparison instructions should return -1 in lanes

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -494,7 +494,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 :math:`\shape\K{.}\vbinop`
 ..........................
 
-1. Assert: due to :ref:`validation <valid-vbinop>`, a value of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
+1. Assert: due to :ref:`validation <valid-vbinop>`, two values of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
 
 2. Pop the value :math:`\V128.\VCONST~c_2` from the stack.
 
@@ -512,10 +512,41 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   (\V128\K{.}\VCONST~c_1)~(\V128\K{.}\VCONST~c_2)~\V128\K{.}\vbinop &\stepto& (\V128\K{.}\VCONST~c)
+   (\V128\K{.}\VCONST~c_1)~(\V128\K{.}\VCONST~c_2)~\shape\K{.}\vbinop &\stepto& (\V128\K{.}\VCONST~c)
      & (\iff c \in \vbinop_{\shape}(c_1, c_2)) \\
-   (\V128\K{.}\VCONST~c_1)~(\V128\K{.}\VCONST~c_2)~\V128\K{.}\vbinop &\stepto& \TRAP
+   (\V128\K{.}\VCONST~c_1)~(\V128\K{.}\VCONST~c_2)~\shape\K{.}\vbinop &\stepto& \TRAP
      & (\iff \vbinop_{\shape}(c_1, c_2) = \{\})
+   \end{array}
+
+
+.. _exec-vrelop:
+
+:math:`t\K{x}N\K{.}\vrelop`
+...........................
+
+1. Assert: due to :ref:`validation <valid-vrelop>`, a value of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
+
+2. Pop the value :math:`\V128.\VCONST~c_2` from the stack.
+
+3. Pop the value :math:`\V128.\VCONST~c_1` from the stack.
+
+4. Let :math:`i^\ast` be the sequence :math:`\lanes_{t\K{x}N}(c_1)`.
+
+5. Let :math:`j^\ast` be the sequence :math:`\lanes_{t\K{x}N}(c_2)`.
+
+6. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t\K{x}N}(\extend^s_{i1,t}(\vrelop_t(i^\ast, j^\ast)))`.
+
+7. Push the value :math:`\V128.\VCONST~c` to the stack.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   (\V128\K{.}\VCONST~c_1)~(\V128\K{.}\VCONST~c_2)~t\K{x}N\K{.}\vrelop &\stepto& (\V128\K{.}\VCONST~c)
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\iff c = \lanes^{-1}_{t\K{x}N}(\extend^x_{i1,t}(\vrelop_t(\lanes_{t\K{x}N}(c_1), \lanes_{t\K{x}N}(c_2)))))
+     \end{array}
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -534,7 +534,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 
 5. Let :math:`j^\ast` be the sequence :math:`\lanes_{t\K{x}N}(c_2)`.
 
-6. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t\K{x}N}(\extend^s_{\i1,t}(\vrelop_t(i^\ast, j^\ast)))`.
+6. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t\K{x}N}(\extends_{1,|t|}(\vrelop_t(i^\ast, j^\ast)))`.
 
 7. Push the value :math:`\V128.\VCONST~c` to the stack.
 
@@ -545,7 +545,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff c = \lanes^{-1}_{t\K{x}N}(\extend^s_{\i1,t}(\vrelop_t(\lanes_{t\K{x}N}(c_1), \lanes_{t\K{x}N}(c_2)))))
+     (\iff c = \lanes^{-1}_{t\K{x}N}(\extends_{1,|t|}(\vrelop_t(\lanes_{t\K{x}N}(c_1), \lanes_{t\K{x}N}(c_2)))))
      \end{array}
    \end{array}
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -494,7 +494,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 :math:`\shape\K{.}\vbinop`
 ..........................
 
-1. Assert: due to :ref:`validation <valid-vbinop>`, two values of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
+1. Assert: due to :ref:`validation <valid-vbinop>`, two values of :ref:`value type <syntax-valtype>` |V128| are on the top of the stack.
 
 2. Pop the value :math:`\V128.\VCONST~c_2` from the stack.
 
@@ -524,7 +524,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 :math:`t\K{x}N\K{.}\vrelop`
 ...........................
 
-1. Assert: due to :ref:`validation <valid-vrelop>`, a value of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
+1. Assert: due to :ref:`validation <valid-vrelop>`, two values of :ref:`value type <syntax-valtype>` |V128| are on the top of the stack.
 
 2. Pop the value :math:`\V128.\VCONST~c_2` from the stack.
 
@@ -534,7 +534,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
 
 5. Let :math:`j^\ast` be the sequence :math:`\lanes_{t\K{x}N}(c_2)`.
 
-6. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t\K{x}N}(\extend^s_{i1,t}(\vrelop_t(i^\ast, j^\ast)))`.
+6. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t\K{x}N}(\extend^s_{\i1,t}(\vrelop_t(i^\ast, j^\ast)))`.
 
 7. Push the value :math:`\V128.\VCONST~c` to the stack.
 
@@ -545,7 +545,7 @@ SIMD instructions are defined in terms of generic numeric operators applied lane
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff c = \lanes^{-1}_{t\K{x}N}(\extend^x_{i1,t}(\vrelop_t(\lanes_{t\K{x}N}(c_1), \lanes_{t\K{x}N}(c_2)))))
+     (\iff c = \lanes^{-1}_{t\K{x}N}(\extend^s_{\i1,t}(\vrelop_t(\lanes_{t\K{x}N}(c_1), \lanes_{t\K{x}N}(c_2)))))
      \end{array}
    \end{array}
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -375,6 +375,7 @@ For the other SIMD instructions, the use of two's complement for the signed inte
 
 .. _syntax-vunop:
 .. _syntax-vbinop:
+.. _syntax-vrelop:
 .. _syntax-vcvtop:
 .. _syntax-vextmul:
 
@@ -391,12 +392,13 @@ Occasionally, it is convenient to group operators together according to the foll
      \VPOPCNT \\
    \production{binary operator} & \vbinop &::=&
      \vibinop ~|~ \vfbinop \\&&|&
-     \virelop ~|~ \vfrelop \\&&|&
      \viminmaxop ~|~ \visatbinop \\&&|&
      \SWIZZLE ~|~
      \VMUL ~|~
      \AVGR\K{\_u} ~|~
      \Q15MULRSAT\K{\_s} \\
+   \production{simd relational operator} & \vrelop &::=&
+     \virelop ~|~ \vfrelop \\&&|&
    \production{conversion operator} & \vcvtop &::=&
      \VTRUNC\K{\_sat} ~|~
      \VEXTEND ~|~

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -398,7 +398,7 @@ Occasionally, it is convenient to group operators together according to the foll
      \AVGR\K{\_u} ~|~
      \Q15MULRSAT\K{\_s} \\
    \production{simd relational operator} & \vrelop &::=&
-     \virelop ~|~ \vfrelop \\&&|&
+     \virelop ~|~ \vfrelop \\
    \production{conversion operator} & \vcvtop &::=&
      \VTRUNC\K{\_sat} ~|~
      \VEXTEND ~|~

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -147,7 +147,6 @@
 
 .. |iM| mathdef:: \xref{syntax/values}{syntax-int}{\X{i}M}
 .. |iN| mathdef:: \xref{syntax/values}{syntax-int}{\X{i}N}
-.. |i1| mathdef:: \xref{syntax/values}{syntax-int}{\X{i1}}
 .. |i8| mathdef:: \xref{syntax/values}{syntax-int}{\X{i8}}
 .. |i16| mathdef:: \xref{syntax/values}{syntax-int}{\X{i16}}
 .. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\X{i32}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -147,6 +147,7 @@
 
 .. |iM| mathdef:: \xref{syntax/values}{syntax-int}{\X{i}M}
 .. |iN| mathdef:: \xref{syntax/values}{syntax-int}{\X{i}N}
+.. |i1| mathdef:: \xref{syntax/values}{syntax-int}{\X{i1}}
 .. |i8| mathdef:: \xref{syntax/values}{syntax-int}{\X{i8}}
 .. |i16| mathdef:: \xref{syntax/values}{syntax-int}{\X{i16}}
 .. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\X{i32}}
@@ -462,6 +463,7 @@
 
 .. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
 .. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
+.. |vrelop| mathdef:: \xref{syntax/instructions}{syntax-vrelop}{\X{vrelop}}
 .. |vternop| mathdef:: \xref{syntax/instructions}{syntax-vternop}{\X{vternop}}
 .. |vcvtop| mathdef:: \xref{syntax/instructions}{syntax-vcvtop}{\X{vcvtop}}
 .. |vextmul| mathdef:: \xref{syntax/instructions}{syntax-vextmul}{\X{vextmul}}

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -351,6 +351,20 @@ We also define an auxiliary function to get number of packed numeric types in a 
    }
 
 
+.. _valid-vrelop:
+
+:math:`\shape\K{.}\vrelop`
+..........................
+
+* The instruction is valid with type :math:`[\V128~\V128] \to [\V128]`.
+
+.. math::
+   \frac{
+   }{
+     C \vdashinstr \shape\K{.}\vrelop : [\V128~\V128] \to [\V128]
+   }
+
+
 .. _valid-vternop:
 
 :math:`\shape\K{.}\vternop`


### PR DESCRIPTION
SIMD comparisons return -1 (all bits set) in the lanes. Currently as
specified, they return 1 (since we use the numeric comparison). We fix
this by extracting these instructions (virelop and vfrelop) into vrelop,
and in the execution, sign extend them from i1 to iX (which treats the
1-bit integer "1" as -1).

Drive-by fix for exec-vbinop, some typos in the execution semantics.

Fixed #441.