### PR TITLE
Small cleanup to num_pat to remove redundant Source.phrase

### DIFF
--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -18,8 +18,7 @@ type nanop = nanop' Source.phrase
 and nanop' = (Lib.void, Lib.void, nan, nan, Lib.void) Values.op
 and nan = CanonicalNan | ArithmeticNan
 
-type num_pat = num_pat' Source.phrase
-and num_pat' =
+type num_pat =
   | LitPat of literal
   | NanPat of nanop
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -813,7 +813,7 @@ let result_simd mode res shape pats =
   (* A different text generation for SIMD, since the literals within
    * a SimdResult do not need the i32.const instruction *)
   let num_pat mode res =
-    match res.it with
+    match res with
     | LitPat lit -> literal mode lit (Some shape)
     | NanPat {it = Values.F32 n; _}
     | NanPat {it = Values.F64 n; _} -> nan n
@@ -826,7 +826,7 @@ let result_simd mode res shape pats =
 let result mode res =
   match res.it with
   | SimdResult (shape, pats) -> result_simd mode res shape pats
-  | NumResult n -> result_numpat mode n.it
+  | NumResult n -> result_numpat mode n
   | RefResult t -> Node ("ref." ^ refed_type t, [])
 
 let assertion mode ass =

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -51,20 +51,20 @@ let simd_literal shape ss at =
 let simd_lane_nan shape l at =
   let open Simd in
   match shape with
-  | F32x4 -> NanPat (Values.F32 l @@ at) @@ at
-  | F64x2 -> NanPat (Values.F64 l @@ at) @@ at
+  | F32x4 -> NanPat (Values.F32 l @@ at)
+  | F64x2 -> NanPat (Values.F64 l @@ at)
   | _ -> error at "invalid simd constant"
 
 let simd_lane_lit shape l at =
   let open Simd in
   let open Values in
   match shape with
-  | I8x16 -> LitPat (Num (I32 (I8.of_string l)) @@ at) @@ at
-  | I16x8 -> LitPat (Num (I32 (I16.of_string l)) @@ at) @@ at
-  | I32x4 -> LitPat (Num (I32 (I32.of_string l)) @@ at) @@ at
-  | I64x2 -> LitPat (Num (I64 (I64.of_string l)) @@ at) @@ at
-  | F32x4 -> LitPat (Num (F32 (F32.of_string l)) @@ at) @@ at
-  | F64x2 -> LitPat (Num (F64 (F64.of_string l)) @@ at) @@ at
+  | I8x16 -> LitPat (Num (I32 (I8.of_string l)) @@ at)
+  | I16x8 -> LitPat (Num (I32 (I16.of_string l)) @@ at)
+  | I32x4 -> LitPat (Num (I32 (I32.of_string l)) @@ at)
+  | I64x2 -> LitPat (Num (I64 (I64.of_string l)) @@ at)
+  | F32x4 -> LitPat (Num (F32 (F32.of_string l)) @@ at)
+  | F64x2 -> LitPat (Num (F64 (F64.of_string l)) @@ at)
 
 let simd_lane_index s at =
   match int_of_string s with
@@ -1127,8 +1127,8 @@ numpat_list:
   | numpat numpat_list { $1 :: $2 }
 
 result :
-  | const { NumResult (LitPat $1 @@ at ()) @@ at () }
-  | LPAR CONST NAN RPAR { NumResult (NanPat (nanop $2 ($3 @@ ati 3)) @@ at ()) @@ at () }
+  | const { NumResult (LitPat $1) @@ at () }
+  | LPAR CONST NAN RPAR { NumResult (NanPat (nanop $2 ($3 @@ ati 3))) @@ at () }
   | LPAR REF_FUNC RPAR { RefResult FuncRefType @@ at () }
   | LPAR REF_EXTERN RPAR { RefResult ExternRefType @@ at () }
   | LPAR V128_CONST SIMD_SHAPE numpat_list RPAR {


### PR DESCRIPTION
Took the chance to clean up the matching logic for SimdResult too.